### PR TITLE
Travis tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,10 +41,10 @@ before_script:
   # Startup the application in the background and continue with the tests
   - ./gradlew bootRun 1> /dev/null &
 script:
+  # Make sure we wait for the application to be up, this also ensures the build is finished etc
+  - ./util/wait-for-app.sh
   - ./gradlew check
   - yarn test
-  # Make sure we wait for the application to be up
-  - ./util/wait-for-app.sh
   - ./src/test/bash/run-e2e.sh
   - ./gradlew generateOpenApiSpec
   - ./gradlew generateJavaClient

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,13 +38,14 @@ before_script:
   - cp src/test/resources/config/keystore.jks src/main/resources/config/keystore.jks # we need the keystore to run our app, and we need our app to run e2e tests
   - chmod +x src/test/bash/*.sh
   - chmod +x util/*.sh
+  # Startup the application in the background and continue with the tests
   - ./gradlew bootRun 1> /dev/null &
-  - sleep 60 # give spring boot some time to start
 script:
   - ./gradlew check
   - yarn test
-  - yarn e2e
-  - ./gradlew bootRepackage -Pprod buildDocker -x test
+  # Make sure we wait for the application to be up
+  - ./util/wait-for-app.sh
+  - ./src/test/bash/run-e2e.sh
   - ./gradlew generateOpenApiSpec
   - ./gradlew generateJavaClient
   - echo "include 'managementportal-client'" >> settings.gradle # make this a sub-project so we can build artifacts and javadoc easily

--- a/src/test/bash/run-e2e.sh
+++ b/src/test/bash/run-e2e.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# do not run e2e tests on travis 'tag' builds
+if [ -z $TRAVIS_TAG ]
+then
+  echo "Running e2e tests"
+  yarn e2e
+else
+  echo "Skipping e2e tests on tag builds"
+fi

--- a/src/test/bash/run-prod-e2e.sh
+++ b/src/test/bash/run-prod-e2e.sh
@@ -20,7 +20,7 @@ then
   ./gradlew bootRepackage -Pprod buildDocker -x test
   docker-compose -f src/main/docker/app.yml up -d # spin up production mode application
   # wait for app to be up
-  ./../../../util/wait-for-app.sh
+  $TRAVIS_BUILD_DIR/util/wait-for-app.sh http://localhost:8080/managementportal/
   docker-compose -f src/main/docker/app.yml logs # show output of app startup
   yarn e2e # run e2e tests against production mode
   docker-compose -f src/main/docker/app.yml down -v # clean up containers and volumes

--- a/src/test/bash/run-prod-e2e.sh
+++ b/src/test/bash/run-prod-e2e.sh
@@ -11,7 +11,7 @@
 set -ev
 
 # only run on the release branch's push and pull_request events
-if [[ $TRAVIS_BRANCH == release-* ]] || [[ $TRAVIS_PULL_REQUEST_BRANCH == release-* ]]
+if [[ $TRAVIS_BRANCH == release-* ]] || [[ $TRAVIS_BRANCH == master ]]
 then
   echo "Running production e2e tests"
   sed -i "s|new plugin.BaseHrefWebpackPlugin({ baseHref: '/' })|new plugin.BaseHrefWebpackPlugin({ baseHref: '/managementportal/' })|" webpack/webpack.dev.js

--- a/src/test/bash/run-prod-e2e.sh
+++ b/src/test/bash/run-prod-e2e.sh
@@ -8,10 +8,8 @@
 # Then we start up a docker stack with a postgres server since production mode is configured for a
 # postgres database instead of in-memory database.
 
-set -ev
-
-# only run on the release branch's push and pull_request events
-if [[ $TRAVIS_BRANCH == release-* ]] || [[ $TRAVIS_BRANCH == master ]]
+# only run on the release branch and master branch if it's not a tag build
+if [[ $TRAVIS_BRANCH == release-* ]] || ( [[ $TRAVIS_BRANCH == master ]] && [ -z $TRAVIS_TAG ] )
 then
   echo "Running production e2e tests"
   sed -i "s|new plugin.BaseHrefWebpackPlugin({ baseHref: '/' })|new plugin.BaseHrefWebpackPlugin({ baseHref: '/managementportal/' })|" webpack/webpack.dev.js

--- a/src/test/bash/test-docker-build-on-release-branch.sh
+++ b/src/test/bash/test-docker-build-on-release-branch.sh
@@ -6,7 +6,12 @@
 
 set -ev
 
-if [[ $TRAVIS_BRANCH == release-* ]]
+# only run on the release branch's push and pull_request events
+if [[ $TRAVIS_BRANCH == release-* ]] || [[ $TRAVIS_PULL_REQUEST_BRANCH == release-* ]]
 then
+  echo "Testing docker image build"
   docker build -t managementportal .
+  ./gradlew bootRepackage -Pprod buildDocker -x test
+else
+  echo "Skipping building docker image"
 fi

--- a/src/test/bash/test-docker-build-on-release-branch.sh
+++ b/src/test/bash/test-docker-build-on-release-branch.sh
@@ -4,10 +4,8 @@
 # we need to put this in it's own file, since Travis will only see the exit status of the if
 # statement.
 
-set -ev
-
-# only run on the release branch's push and pull_request events
-if [[ $TRAVIS_BRANCH == release-* ]] || [[ $TRAVIS_PULL_REQUEST_BRANCH == release-* ]]
+# only run on the release branch and master branch if it's not a tag build
+if [[ $TRAVIS_BRANCH == release-* ]] || ( [[ $TRAVIS_BRANCH == master ]] && [ -z $TRAVIS_TAG ] )
 then
   echo "Testing docker image build"
   docker build -t managementportal .

--- a/util/wait-for-app.sh
+++ b/util/wait-for-app.sh
@@ -9,11 +9,19 @@ else
 fi
 
 # wait for app to start up
-echo "Waiting for application startup"
+echo "Waiting for application startup at $APP_URL"
+RETRY_COUNT=0
 until curl -s $APP_URL > /dev/null
 do
   echo -n "." # waiting
   sleep 2
+  ((RETRY_COUNT++))
+  if ((RETRY_COUNT > 120)) # wait max 120 times, so max 4 minutes
+  then
+    echo ""
+    echo "Application failed to start"
+    exit 1
+  fi
 done
 echo ""
 echo "Application is up"

--- a/util/wait-for-app.sh
+++ b/util/wait-for-app.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# wait for app to start up
+echo "Waiting for application startup"
+until curl -s http://localhost:8080/managementportal/ > /dev/null
+do
+echo -n "." # waiting
+sleep 2
+done
+echo ""
+echo "Application is up"

--- a/util/wait-for-app.sh
+++ b/util/wait-for-app.sh
@@ -1,11 +1,19 @@
 #!/bin/bash
 
+if [ -z $1 ]
+then
+  echo "No URL specified, using http://localhost:8080/"
+  APP_URL='http://localhost:8080/'
+else
+  APP_URL=$1
+fi
+
 # wait for app to start up
 echo "Waiting for application startup"
-until curl -s http://localhost:8080/managementportal/ > /dev/null
+until curl -s $APP_URL > /dev/null
 do
-echo -n "." # waiting
-sleep 2
+  echo -n "." # waiting
+  sleep 2
 done
 echo ""
 echo "Application is up"


### PR DESCRIPTION
A number of tweaks to reduce Travis build times and eliminate unnecessary tests.

- No longer wait 60 seconds for app startup in `before_script`, now we check if the application is up right before we need it. If it's not up we wait for it to be up. This allows the checks to start running while the application is starting up in the background.
- Regular e2e tests do not run on a Travis `tag` build anymore, by the time we tag a commit, these tests will already have run and succeeded.
- Production e2e tests only run on release branches
- Docker builds only run on release branches