### PR TITLE
Use proper builder pattern for OAuth2Client

### DIFF
--- a/oauth-client-util/build.gradle
+++ b/oauth-client-util/build.gradle
@@ -7,11 +7,11 @@ plugins {
     id 'maven-publish'
 }
 
-sourceCompatibility = 1.8
+sourceCompatibility = 1.7
 
-ext.okhttpVersion = '3.6.0'
+ext.okhttpVersion = '3.9.1'
 ext.junitVersion = '4.12'
-ext.jacksonVersion='2.8.5'
+ext.jacksonVersion='2.9.3'
 
 ext.description = 'This library can be used by client applications that want to use the client_credentials OAuth2 flow. It will manage getting the token and renewing it when necessary.'
 
@@ -32,10 +32,7 @@ publishing {
 }
 
 dependencies {
-    api group: 'com.squareup.okhttp3', name: 'okhttp', version: okhttpVersion
-
-    compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.2'
-
+    implementation group: 'com.squareup.okhttp3', name: 'okhttp', version: okhttpVersion
     implementation group: 'com.fasterxml.jackson.core' , name: 'jackson-databind' , version: jacksonVersion
     implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: jacksonVersion
 
@@ -43,7 +40,7 @@ dependencies {
     testCompile group: 'com.github.tomakehurst', name: 'wiremock', version: '2.5.1'
     testCompile group: 'org.mockito', name: 'mockito-core', version: '2.8.47'
     testCompile 'org.glassfish.jersey.core:jersey-common:2.22.2'
-    testCompile 'com.github.stefanbirkner:system-rules:1.16.0'
+    testRuntimeOnly group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.25'
 }
 
 sourceCompatibility = 1.8

--- a/oauth-client-util/src/main/java/org/radarcns/oauth/OAuth2AccessTokenDetails.java
+++ b/oauth-client-util/src/main/java/org/radarcns/oauth/OAuth2AccessTokenDetails.java
@@ -138,52 +138,8 @@ public class OAuth2AccessTokenDetails {
         return accessToken != null && error == null;
     }
 
-    public void setAccessToken(String accessToken) {
-        this.accessToken = accessToken;
-    }
-
-    public void setTokenType(String tokenType) {
-        this.tokenType = tokenType;
-    }
-
-    public void setExpiresIn(long expiresIn) {
-        this.expiresIn = expiresIn;
-    }
-
     public Instant getExpiryDate() {
         return Instant.ofEpochSecond(issueDate + expiresIn);
-    }
-
-    public void setScope(String scope) {
-        this.scope = scope;
-    }
-
-    public void setSubject(String subject) {
-        this.subject = subject;
-    }
-
-    public void setIssuer(String issuer) {
-        this.issuer = issuer;
-    }
-
-    public void setIssueDate(long issueDate) {
-        this.issueDate = issueDate;
-    }
-
-    public void setJsonWebTokenId(String jsonWebTokenId) {
-        this.jsonWebTokenId = jsonWebTokenId;
-    }
-
-    public void setError(String error) {
-        this.error = error;
-    }
-
-    public void setErrorDescription(String errorDescription) {
-        this.errorDescription = errorDescription;
-    }
-
-    public void setMessage(String message) {
-        this.message = message;
     }
 
     /**

--- a/oauth-client-util/src/main/java/org/radarcns/oauth/OAuth2Client.java
+++ b/oauth-client-util/src/main/java/org/radarcns/oauth/OAuth2Client.java
@@ -1,7 +1,11 @@
 package org.radarcns.oauth;
 
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.net.URL;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -10,6 +14,7 @@ import okhttp3.FormBody;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
+import okhttp3.ResponseBody;
 import org.radarcns.exception.TokenException;
 
 /**
@@ -26,50 +31,34 @@ import org.radarcns.exception.TokenException;
  *
  * <p>See the test cases for this class for examples on usage. Also see
  * {@link OAuth2AccessTokenDetails} for more info on how to use it.</p>
+ *
+ * @implSpec this class is not thread-safe.
  */
+// using builder pattern.
+@SuppressWarnings("PMD.MissingStaticMethodInNonInstantiatableClass")
 public class OAuth2Client {
-    private URL tokenEndpoint;
-    private String clientId = "";
-    private String clientSecret = "";
-    private final Set<String> scope = new HashSet<>();
-    private OAuth2AccessTokenDetails currentToken = new OAuth2AccessTokenDetails();
+    private final URL tokenEndpoint;
+    private final Set<String> scope;
+    private final OkHttpClient httpClient;
+    private final String clientCredentials;
 
-    private OkHttpClient httpClient;
+    private OAuth2AccessTokenDetails currentToken;
+
+    private OAuth2Client(URL endpoint, String clientCredentials, Set<String> scopes,
+            OAuth2AccessTokenDetails token, OkHttpClient client) {
+        this.tokenEndpoint = endpoint;
+        this.clientCredentials = clientCredentials;
+        this.scope = scopes;
+        this.currentToken = token;
+        httpClient = client;
+    }
 
     public URL getTokenEndpoint() {
         return tokenEndpoint;
     }
 
-    public String getClientId() {
-        return clientId;
-    }
-
-    public String getClientSecret() {
-        return clientSecret;
-    }
-
     public Set<String> getScope() {
         return scope;
-    }
-
-    public OAuth2Client tokenEndpoint(URL tokenEndpoint) {
-        this.tokenEndpoint = tokenEndpoint;
-        return this;
-    }
-
-    public OAuth2Client clientId(String clientId) {
-        this.clientId = clientId;
-        return this;
-    }
-
-    public OAuth2Client clientSecret(String clientSecret) {
-        this.clientSecret = clientSecret;
-        return this;
-    }
-
-    public OAuth2Client addScope(String scope) {
-        this.scope.add(scope);
-        return this;
     }
 
     /**
@@ -80,51 +69,44 @@ public class OAuth2Client {
      */
     public OAuth2AccessTokenDetails getAccessToken() throws TokenException {
         if (currentToken.isExpired()) {
-            getNewToken();
+            requestToken();
         }
         return currentToken;
     }
 
     /**
-     * Gets the stored {@link OkHttpClient} or creates one if none is stored.
-     * @return the {@link OkHttpClient} instance
+     * Check whether given token is still valid for the given amount of time.
+     * @param timeStillValid duration that the token should still be valid.
+     * @return {@code true} if the token is valid for given duration, {@code false} otherwise.
      */
-    public OkHttpClient getHttpClient() {
-        if (httpClient == null) {
-            // create a client with some default settings
-            httpClient = new OkHttpClient.Builder()
-                    .connectTimeout(10, TimeUnit.SECONDS)
-                    .writeTimeout(10, TimeUnit.SECONDS)
-                    .readTimeout(30, TimeUnit.SECONDS)
-                    .build();
-        }
-        return httpClient;
+    public boolean isTokenValidFor(Duration timeStillValid) {
+        return currentToken.isValid()
+            && Instant.now().plus(timeStillValid).isBefore(currentToken.getExpiryDate());
     }
 
-    public OAuth2Client httpClient(OkHttpClient httpClient) {
-        this.httpClient = httpClient;
-        return this;
-    }
-
-    private void getNewToken() throws TokenException {
+    private void requestToken() throws TokenException {
         // build the form to post to the token endpoint
-        FormBody body = new FormBody.Builder().add("grant_type", "client_credentials")
-                .add("scope", String.join(" ", scope)).build();
-
-        String credential = Credentials.basic(getClientId(), getClientSecret());
+        FormBody body = new FormBody.Builder()
+                .add("grant_type", "client_credentials")
+                .add("scope", String.join(" ", scope))
+                .build();
 
         // build the POST request to the token endpoint with the form data
         Request request = new Request.Builder()
                 .addHeader("Accept", "application/json")
-                .addHeader("Authorization", credential)
+                .addHeader("Authorization", clientCredentials)
                 .url(getTokenEndpoint())
                 .post(body)
                 .build();
 
         // make the client execute the POST request
-        try (Response response = getHttpClient().newCall(request).execute()) {
+        try (Response response = httpClient.newCall(request).execute()) {
             if (response.isSuccessful()) {
-                currentToken = OAuth2AccessTokenDetails.getObject(response);
+                ResponseBody responseBody = response.body();
+                if (responseBody == null) {
+                    throw new TokenException("No response from server");
+                }
+                currentToken = OAuth2AccessTokenDetails.getObject(responseBody.string());
             } else {
                 throw new TokenException("Cannot get a valid token : Response-code :"
                         + response.code() + " received when requesting token from server with "
@@ -133,6 +115,64 @@ public class OAuth2Client {
 
         } catch (IOException e) {
             throw new TokenException(e);
+        }
+    }
+
+    /** Builder for an OAuth2 client. The endpoint and credentials settings are mandatory. */
+    public static class Builder {
+        private URL tokenEndpoint;
+        private final Set<String> scopeSet = new HashSet<>();
+        private OAuth2AccessTokenDetails currentToken = new OAuth2AccessTokenDetails();
+        private OkHttpClient okHttpClient;
+        private String clientCredentials;
+
+        public Builder endpoint(URL url) {
+            this.tokenEndpoint = url;
+            return this;
+        }
+
+        public Builder endpoint(URL mpBaseUrl, String tokenPath) throws MalformedURLException {
+            tokenEndpoint = new URL(mpBaseUrl, tokenPath);
+            return this;
+        }
+
+        public Builder credentials(String id, String secret) {
+            clientCredentials = Credentials.basic(id, secret);
+            return this;
+        }
+
+        public Builder scopes(String... scopes) {
+            scopeSet.addAll(Arrays.asList(scopes));
+            return this;
+        }
+
+        public Builder token(OAuth2AccessTokenDetails token) {
+            currentToken = token;
+            return this;
+        }
+
+        public Builder httpClient(OkHttpClient client) {
+            okHttpClient = client;
+            return this;
+        }
+
+        /** Build an OAuth2Client based on the settings given. */
+        public OAuth2Client build() {
+            if (clientCredentials == null) {
+                throw new IllegalStateException("Client credentials missing");
+            }
+            if (tokenEndpoint == null) {
+                throw new IllegalStateException("Token endpoint missing");
+            }
+            if (okHttpClient == null) {
+                okHttpClient = new OkHttpClient.Builder()
+                    .connectTimeout(10, TimeUnit.SECONDS)
+                    .writeTimeout(10, TimeUnit.SECONDS)
+                    .readTimeout(30, TimeUnit.SECONDS)
+                    .build();
+            }
+            return new OAuth2Client(tokenEndpoint, clientCredentials, scopeSet, currentToken,
+                okHttpClient);
         }
     }
 }

--- a/oauth-client-util/src/main/java/org/radarcns/oauth/OAuth2Client.java
+++ b/oauth-client-util/src/main/java/org/radarcns/oauth/OAuth2Client.java
@@ -32,7 +32,7 @@ import org.radarcns.exception.TokenException;
  * <p>See the test cases for this class for examples on usage. Also see
  * {@link OAuth2AccessTokenDetails} for more info on how to use it.</p>
  *
- * @implSpec this class is not thread-safe.
+ * @implSpec this class is thread-safe.
  */
 // using builder pattern.
 @SuppressWarnings("PMD.MissingStaticMethodInNonInstantiatableClass")
@@ -42,14 +42,14 @@ public class OAuth2Client {
     private final OkHttpClient httpClient;
     private final String clientCredentials;
 
-    private OAuth2AccessTokenDetails currentToken;
+    private OAuth2AccessTokenDetails token;
 
     private OAuth2Client(URL endpoint, String clientCredentials, Set<String> scopes,
             OAuth2AccessTokenDetails token, OkHttpClient client) {
         this.tokenEndpoint = endpoint;
         this.clientCredentials = clientCredentials;
         this.scope = scopes;
-        this.currentToken = token;
+        this.token = token;
         httpClient = client;
     }
 
@@ -62,16 +62,37 @@ public class OAuth2Client {
     }
 
     /**
+     * Get the current token.
+     */
+    public synchronized OAuth2AccessTokenDetails getToken() {
+        return token;
+    }
+
+
+    /**
      * Get the access token. This method will automatically request a new access token if the
-     * current one is expired.
+     * current one will expire before 10 seconds.
      * @return the access token
      * @throws TokenException if a new access token could not be fetched
      */
-    public OAuth2AccessTokenDetails getAccessToken() throws TokenException {
-        if (currentToken.isExpired()) {
-            requestToken();
+    public OAuth2AccessTokenDetails getValidToken() throws TokenException {
+        return getValidToken(Duration.ofSeconds(10));
+    }
+
+    /**
+     * Get the access token. This method will automatically request a new access token if the
+     * current one will expire before given validity duration.
+     * @param validity time until the current token will become invalid
+     * @return the access token
+     * @throws TokenException if a new access token could not be fetched
+     */
+    public OAuth2AccessTokenDetails getValidToken(Duration validity) throws TokenException {
+        synchronized (this) {
+            if (isTokenValidFor(validity)) {
+                return token;
+            }
         }
-        return currentToken;
+        return refreshToken();
     }
 
     /**
@@ -79,12 +100,17 @@ public class OAuth2Client {
      * @param timeStillValid duration that the token should still be valid.
      * @return {@code true} if the token is valid for given duration, {@code false} otherwise.
      */
-    public boolean isTokenValidFor(Duration timeStillValid) {
-        return currentToken.isValid()
-            && Instant.now().plus(timeStillValid).isBefore(currentToken.getExpiryDate());
+    public synchronized boolean isTokenValidFor(Duration timeStillValid) {
+        return token.isValid()
+            && Instant.now().plus(timeStillValid).isBefore(token.getExpiryDate());
     }
 
-    private void requestToken() throws TokenException {
+    /**
+     * Refresh the current token. This will update the token value of this class.
+     * @return the new refreshed token
+     * @throws TokenException if the token could not be refreshed.
+     */
+    public OAuth2AccessTokenDetails refreshToken() throws TokenException {
         // build the form to post to the token endpoint
         FormBody body = new FormBody.Builder()
                 .add("grant_type", "client_credentials")
@@ -106,13 +132,19 @@ public class OAuth2Client {
                 if (responseBody == null) {
                     throw new TokenException("No response from server");
                 }
-                currentToken = OAuth2AccessTokenDetails.getObject(responseBody.string());
+                OAuth2AccessTokenDetails localToken = OAuth2AccessTokenDetails.getObject(
+                        responseBody.string());
+
+                synchronized (this) {
+                    token = localToken;
+                }
+
+                return localToken;
             } else {
                 throw new TokenException("Cannot get a valid token : Response-code :"
                         + response.code() + " received when requesting token from server with "
                         + "message " + response.message());
             }
-
         } catch (IOException e) {
             throw new TokenException(e);
         }

--- a/oauth-client-util/src/test/java/org/radarcns/oauth/unit/OAuth2AccessTokenDetailsTest.java
+++ b/oauth-client-util/src/test/java/org/radarcns/oauth/unit/OAuth2AccessTokenDetailsTest.java
@@ -1,6 +1,7 @@
 package org.radarcns.oauth.unit;
 
 import org.junit.Test;
+import org.radarcns.exception.TokenException;
 import org.radarcns.oauth.OAuth2AccessTokenDetails;
 
 import java.time.Instant;
@@ -26,10 +27,12 @@ public class OAuth2AccessTokenDetailsTest {
     }
 
     @Test
-    public void testTokenNotExpired() {
-        OAuth2AccessTokenDetails token = new OAuth2AccessTokenDetails();
-        token.setIssueDate(Instant.now().getEpochSecond());
-        token.setExpiresIn(30);
+    public void testTokenNotExpired() throws TokenException {
+        String body =
+                "{\"expires_in\":30"
+                + ",\"iat\":" + Instant.now().getEpochSecond()
+                + ",\"access_token\":\"abcdef\"}";
+        OAuth2AccessTokenDetails token = OAuth2AccessTokenDetails.getObject(body);
         assertFalse(token.isExpired());
     }
 }

--- a/oauth-client-util/src/test/java/org/radarcns/oauth/unit/OAuth2ClientTest.java
+++ b/oauth-client-util/src/test/java/org/radarcns/oauth/unit/OAuth2ClientTest.java
@@ -107,7 +107,7 @@ public class OAuth2ClientTest {
                 .scopes("read")
                 .httpClient(httpClient)
                 .build();
-        OAuth2AccessTokenDetails token = client.getAccessToken();
+        OAuth2AccessTokenDetails token = client.getValidToken();
         assertTrue(token.isValid());
         assertFalse(token.isExpired());
         assertEquals(accessToken, token.getAccessToken());
@@ -132,7 +132,7 @@ public class OAuth2ClientTest {
         OAuth2Client client = clientBuilder
                 .scopes("write")
                 .build();
-        client.getAccessToken();
+        client.getValidToken();
     }
 
     @Test(expected = TokenException.class)
@@ -145,7 +145,7 @@ public class OAuth2ClientTest {
         OAuth2Client client = clientBuilder
                 .scopes("read")
                 .build();
-        client.getAccessToken();
+        client.getValidToken();
     }
 
     @Test(expected = TokenException.class)
@@ -158,7 +158,7 @@ public class OAuth2ClientTest {
         OAuth2Client client = clientBuilder
                 .scopes("read")
                 .build();
-        client.getAccessToken();
+        client.getValidToken(Duration.ofSeconds(30));
     }
 
     @Test(expected = TokenException.class)
@@ -171,7 +171,7 @@ public class OAuth2ClientTest {
         OAuth2Client client = clientBuilder
                 .scopes("read")
                 .build();
-        client.getAccessToken();
+        client.getValidToken(Duration.ofSeconds(30));
     }
 
     @Test(expected = TokenException.class)
@@ -182,7 +182,7 @@ public class OAuth2ClientTest {
                 .endpoint(new URL("http://localhost:9000"))
                 .scopes("read")
                 .build();
-        client.getAccessToken();
+        client.getValidToken();
     }
 
     @Test(expected = TokenException.class)
@@ -195,7 +195,7 @@ public class OAuth2ClientTest {
         OAuth2Client client = clientBuilder
                 .scopes("read")
                 .build();
-        client.getAccessToken();
+        client.getValidToken();
     }
 
     @Test(expected = TokenException.class)
@@ -208,7 +208,7 @@ public class OAuth2ClientTest {
         OAuth2Client client = clientBuilder
                 .scopes("read")
                 .build();
-        client.getAccessToken();
+        client.getValidToken();
     }
 
     private String successfulResponse() {

--- a/oauth-client-util/src/test/java/org/radarcns/oauth/unit/OAuth2ClientTest.java
+++ b/oauth-client-util/src/test/java/org/radarcns/oauth/unit/OAuth2ClientTest.java
@@ -1,7 +1,9 @@
 package org.radarcns.oauth.unit;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import okhttp3.OkHttpClient;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.radarcns.exception.TokenException;
@@ -11,7 +13,9 @@ import org.radarcns.oauth.OAuth2Client;
 import javax.ws.rs.core.HttpHeaders;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.time.Duration;
 import java.time.Instant;
+import java.util.concurrent.TimeUnit;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
@@ -19,6 +23,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -30,14 +35,23 @@ public class OAuth2ClientTest {
     public WireMockRule wireMockRule = new WireMockRule(8089);
 
     private URL tokenEndpoint;
+    private static OkHttpClient httpClient;
 
+    /** Set up custom HTTP client. */
+    @BeforeClass
+    public static void setUpClass() {
+        httpClient = new OkHttpClient.Builder()
+            .connectTimeout(10, TimeUnit.SECONDS)
+            .writeTimeout(10, TimeUnit.SECONDS)
+            .readTimeout(30, TimeUnit.SECONDS)
+            .build();
+    }
 
     @Before
     public void init() throws MalformedURLException {
         tokenIssueDate = Instant.now().getEpochSecond();
         tokenEndpoint = new URL("http://localhost:8089/oauth/token");
     }
-
 
     @Test
     public void testValidTokenResponse() throws TokenException {
@@ -46,17 +60,20 @@ public class OAuth2ClientTest {
                         .withStatus(200)
                         .withHeader(HttpHeaders.CONTENT_TYPE, "application/json")
                         .withBody(successfulResponse())));
-        OAuth2Client client = new OAuth2Client()
-                .clientId("client")
-                .clientSecret("secret")
-                .tokenEndpoint(tokenEndpoint)
-                .addScope("read");
+        OAuth2Client client = new OAuth2Client.Builder()
+                .credentials("client", "secret")
+                .endpoint(tokenEndpoint)
+                .scopes("read")
+                .httpClient(httpClient)
+                .build();
         OAuth2AccessTokenDetails token = client.getAccessToken();
         assertTrue(token.isValid());
         assertFalse(token.isExpired());
         assertEquals(accessToken, token.getAccessToken());
         assertEquals("bearer", token.getTokenType());
         assertEquals(1799L, token.getExpiresIn());
+        assertTrue(client.isTokenValidFor(Duration.ofSeconds(1700)));
+        assertFalse(client.isTokenValidFor(Duration.ofSeconds(1900)));
         assertEquals(tokenIssueDate, token.getIssueDate());
         assertEquals("radar_restapi", token.getSubject());
         assertEquals("read", token.getScope());
@@ -71,11 +88,11 @@ public class OAuth2ClientTest {
                         .withStatus(400)
                         .withHeader(HttpHeaders.CONTENT_TYPE, "application/json")
                         .withBody(invalidScopeResponse)));
-        OAuth2Client client = new OAuth2Client()
-                .clientId("client")
-                .clientSecret("secret")
-                .tokenEndpoint(tokenEndpoint)
-                .addScope("write");
+        OAuth2Client client = new OAuth2Client.Builder()
+                .credentials("client", "secret")
+                .endpoint(tokenEndpoint)
+                .scopes("write")
+                .build();
         client.getAccessToken();
     }
 
@@ -86,11 +103,11 @@ public class OAuth2ClientTest {
                         .withStatus(401)
                         .withHeader(HttpHeaders.CONTENT_TYPE, "application/json")
                         .withBody(invalidCredentialsResponse)));
-        OAuth2Client client = new OAuth2Client()
-                .clientId("client")
-                .clientSecret("secret")
-                .tokenEndpoint(tokenEndpoint)
-                .addScope("read");
+        OAuth2Client client = new OAuth2Client.Builder()
+                .credentials("client", "secret")
+                .endpoint(tokenEndpoint)
+                .scopes("read")
+                .build();
         client.getAccessToken();
     }
 
@@ -101,11 +118,11 @@ public class OAuth2ClientTest {
                         .withStatus(401)
                         .withHeader(HttpHeaders.CONTENT_TYPE, "application/json")
                         .withBody(invalidGrantTypeResponse)));
-        OAuth2Client client = new OAuth2Client()
-                .clientId("client")
-                .clientSecret("secret")
-                .tokenEndpoint(tokenEndpoint)
-                .addScope("read");
+        OAuth2Client client = new OAuth2Client.Builder()
+                .credentials("client",  "secret")
+                .endpoint(tokenEndpoint)
+                .scopes("read")
+                .build();
         client.getAccessToken();
     }
 
@@ -116,23 +133,23 @@ public class OAuth2ClientTest {
                         .withStatus(401)
                         .withHeader(HttpHeaders.CONTENT_TYPE, "application/json")
                         .withBody(invalidTypesResponse())));
-        OAuth2Client client = new OAuth2Client()
-                .clientId("client")
-                .clientSecret("secret")
-                .tokenEndpoint(tokenEndpoint)
-                .addScope("read");
+        OAuth2Client client = new OAuth2Client.Builder()
+                .credentials("client", "secret")
+                .endpoint(tokenEndpoint)
+                .scopes("read")
+                .build();
         client.getAccessToken();
     }
 
     @Test(expected = TokenException.class)
     public void testUnreachableServer() throws MalformedURLException, TokenException {
         // no http stub here so the location will be unreachable
-        OAuth2Client client = new OAuth2Client()
-                .clientId("client")
-                .clientSecret("secret")
+        OAuth2Client client = new OAuth2Client.Builder()
+                .credentials("client", "secret")
                 // different port in case wiremock is not cleaned up yet
-                .tokenEndpoint(new URL("http://localhost:9000"))
-                .addScope("read");
+                .endpoint(new URL("http://localhost:9000"))
+                .scopes("read")
+                .build();
         client.getAccessToken();
     }
 
@@ -143,11 +160,11 @@ public class OAuth2ClientTest {
                         .withStatus(200)
                         .withHeader(HttpHeaders.CONTENT_TYPE, "application/html")
                         .withBody("<html>Oops, no JSON here</html>")));
-        OAuth2Client client = new OAuth2Client()
-                .clientId("client")
-                .clientSecret("secret")
-                .tokenEndpoint(tokenEndpoint)
-                .addScope("read");
+        OAuth2Client client = new OAuth2Client.Builder()
+                .credentials("client", "secret")
+                .endpoint(tokenEndpoint)
+                .scopes("read")
+                .build();
         client.getAccessToken();
     }
 
@@ -158,11 +175,11 @@ public class OAuth2ClientTest {
                         .withStatus(404)
                         .withHeader(HttpHeaders.CONTENT_TYPE, "application/json")
                         .withBody(notFoundResponse)));
-        OAuth2Client client = new OAuth2Client()
-                .clientId("client")
-                .clientSecret("secret")
-                .tokenEndpoint(tokenEndpoint)
-                .addScope("read");
+        OAuth2Client client = new OAuth2Client.Builder()
+                .credentials("client", "secret")
+                .endpoint(tokenEndpoint)
+                .scopes("read")
+                .build();
         client.getAccessToken();
     }
 
@@ -194,7 +211,8 @@ public class OAuth2ClientTest {
                 + "}";
     }
 
-    private String accessToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJyYWRhcl9yZXN0YXBp"
+    private static final String accessToken =
+            "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJyYWRhcl9yZXN0YXBp"
             + "Iiwi19NYW5hZ2VtZW50UG9ydGFsIl0sInNvdXJjZXMiOltdLCJzY29wZSI6WyJyZWFkIl0sImlzcyI6Ik1hb"
             + "mFnZW1lbnleHAiOjE1MDQwODU3MzEsImlhdCI6MTUwNDA4MzkzMSwiYXV0aG9yaXRpZXMiOlsiUk9MRV9VU0"
             + "VSIl0sImp0aSI6TJmMTItNDQxMi1iZGVjLTc5YzMxNWY3NGM3OSIsImNsaWVudF9pZCI6InJhZGFyX3Jlc3R"
@@ -206,16 +224,16 @@ public class OAuth2ClientTest {
             + "UH9CHHKOVdcK9N3gLKo30ETVDib-bZS-rDESHDvnYppgTH6i31wfjl80NCQhSpB3GyXAR2YHfoTj4VbEzGKs"
             + "LEfS7g-4hSH2kY4-srOAH5TeI2snKbh76mFL8SOTuZrHf-F5KwWPqB82OzAr899eFk6uiNd5Uz7dICyEKyS7"
             + "v-HQ";
-    private String accessTokenId = "5b9fc645-2f12-4412-bdec-79c315f74c79";
+    private static final String accessTokenId = "5b9fc645-2f12-4412-bdec-79c315f74c79";
     private long tokenIssueDate;
 
-    private String invalidScopeResponse = "{\n"
+    private static final String invalidScopeResponse = "{\n"
             + "  \"error\" : \"invalid_scope\",\n"
             + "  \"error_description\" : \"Invalid scope: write\",\n"
             + "  \"scope\" : \"read\"\n"
             + "}\n";
 
-    private String invalidCredentialsResponse = "{\n"
+    private static final String invalidCredentialsResponse = "{\n"
             + "  \"timestamp\" : \"2017-08-31T09:50:19.779+0000\",\n"
             + "  \"status\" : 401,\n"
             + "  \"error\" : \"Unauthorized\",\n"
@@ -223,12 +241,12 @@ public class OAuth2ClientTest {
             + "  \"path\" : \"/oauth/token\""
             + "}";
 
-    private String invalidGrantTypeResponse = "{\n"
+    private static final String invalidGrantTypeResponse = "{\n"
             + "  \"error\" : \"invalid_client\",\n"
             + "  \"error_description\" : \"Unauthorized grant type: client_credentials\"\n"
             + "}";
 
-    private String notFoundResponse = "{\n"
+    private static final String notFoundResponse = "{\n"
             + "  \"timestamp\" : \"2017-08-31T12:00:56.274+0000\",\n"
             + "  \"status\" : 404,\n"
             + "  \"error\" : \"Not Found\",\n"

--- a/oauth-client-util/src/test/java/org/radarcns/oauth/unit/OAuth2ClientTest.java
+++ b/oauth-client-util/src/test/java/org/radarcns/oauth/unit/OAuth2ClientTest.java
@@ -30,7 +30,7 @@ import static org.junit.Assert.assertTrue;
  */
 public class OAuth2ClientTest {
     private static final String accessToken =
-        "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJyYWRhcl9yZXN0YXBp"
+            "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJyYWRhcl9yZXN0YXBp"
             + "Iiwi19NYW5hZ2VtZW50UG9ydGFsIl0sInNvdXJjZXMiOltdLCJzY29wZSI6WyJyZWFkIl0sImlzcyI6Ik1hb"
             + "mFnZW1lbnleHAiOjE1MDQwODU3MzEsImlhdCI6MTUwNDA4MzkzMSwiYXV0aG9yaXRpZXMiOlsiUk9MRV9VU0"
             + "VSIl0sImp0aSI6TJmMTItNDQxMi1iZGVjLTc5YzMxNWY3NGM3OSIsImNsaWVudF9pZCI6InJhZGFyX3Jlc3R"
@@ -46,37 +46,37 @@ public class OAuth2ClientTest {
     private long tokenIssueDate;
 
     private static final String invalidScopeResponse = "{\n"
-        + "  \"error\" : \"invalid_scope\",\n"
-        + "  \"error_description\" : \"Invalid scope: write\",\n"
-        + "  \"scope\" : \"read\"\n"
-        + "}\n";
+            + "  \"error\" : \"invalid_scope\",\n"
+            + "  \"error_description\" : \"Invalid scope: write\",\n"
+            + "  \"scope\" : \"read\"\n"
+            + "}\n";
 
     private static final String invalidCredentialsResponse = "{\n"
-        + "  \"timestamp\" : \"2017-08-31T09:50:19.779+0000\",\n"
-        + "  \"status\" : 401,\n"
-        + "  \"error\" : \"Unauthorized\",\n"
-        + "  \"message\" : \"Bad credentials\",\n"
-        + "  \"path\" : \"/oauth/token\""
-        + "}";
+            + "  \"timestamp\" : \"2017-08-31T09:50:19.779+0000\",\n"
+            + "  \"status\" : 401,\n"
+            + "  \"error\" : \"Unauthorized\",\n"
+            + "  \"message\" : \"Bad credentials\",\n"
+            + "  \"path\" : \"/oauth/token\""
+            + "}";
 
     private static final String invalidGrantTypeResponse = "{\n"
-        + "  \"error\" : \"invalid_client\",\n"
-        + "  \"error_description\" : \"Unauthorized grant type: client_credentials\"\n"
-        + "}";
+            + "  \"error\" : \"invalid_client\",\n"
+            + "  \"error_description\" : \"Unauthorized grant type: client_credentials\"\n"
+            + "}";
 
     private static final String notFoundResponse = "{\n"
-        + "  \"timestamp\" : \"2017-08-31T12:00:56.274+0000\",\n"
-        + "  \"status\" : 404,\n"
-        + "  \"error\" : \"Not Found\",\n"
-        + "  \"message\" : \"Not Found\",\n"
-        + "  \"path\" : \"/oauth/token\"\n"
-        + "}\n";
+            + "  \"timestamp\" : \"2017-08-31T12:00:56.274+0000\",\n"
+            + "  \"status\" : 404,\n"
+            + "  \"error\" : \"Not Found\",\n"
+            + "  \"message\" : \"Not Found\",\n"
+            + "  \"path\" : \"/oauth/token\"\n"
+            + "}\n";
 
     @Rule
     public WireMockRule wireMockRule = new WireMockRule(8089);
 
-    private URL tokenEndpoint;
     private static OkHttpClient httpClient;
+    private OAuth2Client.Builder clientBuilder;
 
     /** Set up custom HTTP client. */
     @BeforeClass
@@ -91,7 +91,9 @@ public class OAuth2ClientTest {
     @Before
     public void init() throws MalformedURLException {
         tokenIssueDate = Instant.now().getEpochSecond();
-        tokenEndpoint = new URL("http://localhost:8089/oauth/token");
+        clientBuilder = new OAuth2Client.Builder()
+            .credentials("client", "secret")
+            .endpoint(new URL("http://localhost:8089/oauth/token"));
     }
 
     @Test
@@ -101,9 +103,7 @@ public class OAuth2ClientTest {
                         .withStatus(200)
                         .withHeader(HttpHeaders.CONTENT_TYPE, "application/json")
                         .withBody(successfulResponse())));
-        OAuth2Client client = new OAuth2Client.Builder()
-                .credentials("client", "secret")
-                .endpoint(tokenEndpoint)
+        OAuth2Client client = clientBuilder
                 .scopes("read")
                 .httpClient(httpClient)
                 .build();
@@ -129,9 +129,7 @@ public class OAuth2ClientTest {
                         .withStatus(400)
                         .withHeader(HttpHeaders.CONTENT_TYPE, "application/json")
                         .withBody(invalidScopeResponse)));
-        OAuth2Client client = new OAuth2Client.Builder()
-                .credentials("client", "secret")
-                .endpoint(tokenEndpoint)
+        OAuth2Client client = clientBuilder
                 .scopes("write")
                 .build();
         client.getAccessToken();
@@ -144,9 +142,7 @@ public class OAuth2ClientTest {
                         .withStatus(401)
                         .withHeader(HttpHeaders.CONTENT_TYPE, "application/json")
                         .withBody(invalidCredentialsResponse)));
-        OAuth2Client client = new OAuth2Client.Builder()
-                .credentials("client", "secret")
-                .endpoint(tokenEndpoint)
+        OAuth2Client client = clientBuilder
                 .scopes("read")
                 .build();
         client.getAccessToken();
@@ -159,9 +155,7 @@ public class OAuth2ClientTest {
                         .withStatus(401)
                         .withHeader(HttpHeaders.CONTENT_TYPE, "application/json")
                         .withBody(invalidGrantTypeResponse)));
-        OAuth2Client client = new OAuth2Client.Builder()
-                .credentials("client",  "secret")
-                .endpoint(tokenEndpoint)
+        OAuth2Client client = clientBuilder
                 .scopes("read")
                 .build();
         client.getAccessToken();
@@ -174,9 +168,7 @@ public class OAuth2ClientTest {
                         .withStatus(401)
                         .withHeader(HttpHeaders.CONTENT_TYPE, "application/json")
                         .withBody(invalidTypesResponse())));
-        OAuth2Client client = new OAuth2Client.Builder()
-                .credentials("client", "secret")
-                .endpoint(tokenEndpoint)
+        OAuth2Client client = clientBuilder
                 .scopes("read")
                 .build();
         client.getAccessToken();
@@ -185,8 +177,7 @@ public class OAuth2ClientTest {
     @Test(expected = TokenException.class)
     public void testUnreachableServer() throws MalformedURLException, TokenException {
         // no http stub here so the location will be unreachable
-        OAuth2Client client = new OAuth2Client.Builder()
-                .credentials("client", "secret")
+        OAuth2Client client = clientBuilder
                 // different port in case wiremock is not cleaned up yet
                 .endpoint(new URL("http://localhost:9000"))
                 .scopes("read")
@@ -201,9 +192,7 @@ public class OAuth2ClientTest {
                         .withStatus(200)
                         .withHeader(HttpHeaders.CONTENT_TYPE, "application/html")
                         .withBody("<html>Oops, no JSON here</html>")));
-        OAuth2Client client = new OAuth2Client.Builder()
-                .credentials("client", "secret")
-                .endpoint(tokenEndpoint)
+        OAuth2Client client = clientBuilder
                 .scopes("read")
                 .build();
         client.getAccessToken();
@@ -216,9 +205,7 @@ public class OAuth2ClientTest {
                         .withStatus(404)
                         .withHeader(HttpHeaders.CONTENT_TYPE, "application/json")
                         .withBody(notFoundResponse)));
-        OAuth2Client client = new OAuth2Client.Builder()
-                .credentials("client", "secret")
-                .endpoint(tokenEndpoint)
+        OAuth2Client client = clientBuilder
                 .scopes("read")
                 .build();
         client.getAccessToken();

--- a/oauth-client-util/src/test/java/org/radarcns/oauth/unit/OAuth2ClientTest.java
+++ b/oauth-client-util/src/test/java/org/radarcns/oauth/unit/OAuth2ClientTest.java
@@ -23,13 +23,54 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /**
  * Created by dverbeec on 31/08/2017.
  */
 public class OAuth2ClientTest {
+    private static final String accessToken =
+        "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJyYWRhcl9yZXN0YXBp"
+            + "Iiwi19NYW5hZ2VtZW50UG9ydGFsIl0sInNvdXJjZXMiOltdLCJzY29wZSI6WyJyZWFkIl0sImlzcyI6Ik1hb"
+            + "mFnZW1lbnleHAiOjE1MDQwODU3MzEsImlhdCI6MTUwNDA4MzkzMSwiYXV0aG9yaXRpZXMiOlsiUk9MRV9VU0"
+            + "VSIl0sImp0aSI6TJmMTItNDQxMi1iZGVjLTc5YzMxNWY3NGM3OSIsImNsaWVudF9pZCI6InJhZGFyX3Jlc3R"
+            + "hcGkifQ.J0TEFQAUnH9RFaplURHrbeLelgbAr3CS7os_Y5S6836TFZyDe4mz4LqhxJLquXxTNP3DYddOKDD_"
+            + "RQ1t0nIDfx0hFJawPB3AjVqobRLOtFQWWdtYYmPbDXVQkdK41iVDhl_15BBxxOlT0pFQfkq4wk22ubq5cg8V"
+            + "Z57xDkrfgaIbdowntnK9GqLy6mDtaPdQV23VDr3whkjEq2YJ9AQBj4KiOWEVAYuNwhZFwHwInsYPZTs2RNK5"
+            + "WkdW2pe4sXGc7BDgUykpUWEMtL7BoyTZEGO5VqDkwcbio1zJDGB5dPm8VHWtlg4tH098BhsFrVE3zOJ9D0Ai"
+            + "62JWZkzr24lH9QjBwruxifyu4AvcLp_AxmO7m_r1bLcDuh6Yt4Ntm1bhGoB_PrygiOFPMn2-VnUH9zTxpZaK"
+            + "UH9CHHKOVdcK9N3gLKo30ETVDib-bZS-rDESHDvnYppgTH6i31wfjl80NCQhSpB3GyXAR2YHfoTj4VbEzGKs"
+            + "LEfS7g-4hSH2kY4-srOAH5TeI2snKbh76mFL8SOTuZrHf-F5KwWPqB82OzAr899eFk6uiNd5Uz7dICyEKyS7"
+            + "v-HQ";
+    private static final String accessTokenId = "5b9fc645-2f12-4412-bdec-79c315f74c79";
+    private long tokenIssueDate;
+
+    private static final String invalidScopeResponse = "{\n"
+        + "  \"error\" : \"invalid_scope\",\n"
+        + "  \"error_description\" : \"Invalid scope: write\",\n"
+        + "  \"scope\" : \"read\"\n"
+        + "}\n";
+
+    private static final String invalidCredentialsResponse = "{\n"
+        + "  \"timestamp\" : \"2017-08-31T09:50:19.779+0000\",\n"
+        + "  \"status\" : 401,\n"
+        + "  \"error\" : \"Unauthorized\",\n"
+        + "  \"message\" : \"Bad credentials\",\n"
+        + "  \"path\" : \"/oauth/token\""
+        + "}";
+
+    private static final String invalidGrantTypeResponse = "{\n"
+        + "  \"error\" : \"invalid_client\",\n"
+        + "  \"error_description\" : \"Unauthorized grant type: client_credentials\"\n"
+        + "}";
+
+    private static final String notFoundResponse = "{\n"
+        + "  \"timestamp\" : \"2017-08-31T12:00:56.274+0000\",\n"
+        + "  \"status\" : 404,\n"
+        + "  \"error\" : \"Not Found\",\n"
+        + "  \"message\" : \"Not Found\",\n"
+        + "  \"path\" : \"/oauth/token\"\n"
+        + "}\n";
 
     @Rule
     public WireMockRule wireMockRule = new WireMockRule(8089);
@@ -210,47 +251,4 @@ public class OAuth2ClientTest {
                 + "  \"jti\" : \"" + accessTokenId + "\"\n"
                 + "}";
     }
-
-    private static final String accessToken =
-            "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJyYWRhcl9yZXN0YXBp"
-            + "Iiwi19NYW5hZ2VtZW50UG9ydGFsIl0sInNvdXJjZXMiOltdLCJzY29wZSI6WyJyZWFkIl0sImlzcyI6Ik1hb"
-            + "mFnZW1lbnleHAiOjE1MDQwODU3MzEsImlhdCI6MTUwNDA4MzkzMSwiYXV0aG9yaXRpZXMiOlsiUk9MRV9VU0"
-            + "VSIl0sImp0aSI6TJmMTItNDQxMi1iZGVjLTc5YzMxNWY3NGM3OSIsImNsaWVudF9pZCI6InJhZGFyX3Jlc3R"
-            + "hcGkifQ.J0TEFQAUnH9RFaplURHrbeLelgbAr3CS7os_Y5S6836TFZyDe4mz4LqhxJLquXxTNP3DYddOKDD_"
-            + "RQ1t0nIDfx0hFJawPB3AjVqobRLOtFQWWdtYYmPbDXVQkdK41iVDhl_15BBxxOlT0pFQfkq4wk22ubq5cg8V"
-            + "Z57xDkrfgaIbdowntnK9GqLy6mDtaPdQV23VDr3whkjEq2YJ9AQBj4KiOWEVAYuNwhZFwHwInsYPZTs2RNK5"
-            + "WkdW2pe4sXGc7BDgUykpUWEMtL7BoyTZEGO5VqDkwcbio1zJDGB5dPm8VHWtlg4tH098BhsFrVE3zOJ9D0Ai"
-            + "62JWZkzr24lH9QjBwruxifyu4AvcLp_AxmO7m_r1bLcDuh6Yt4Ntm1bhGoB_PrygiOFPMn2-VnUH9zTxpZaK"
-            + "UH9CHHKOVdcK9N3gLKo30ETVDib-bZS-rDESHDvnYppgTH6i31wfjl80NCQhSpB3GyXAR2YHfoTj4VbEzGKs"
-            + "LEfS7g-4hSH2kY4-srOAH5TeI2snKbh76mFL8SOTuZrHf-F5KwWPqB82OzAr899eFk6uiNd5Uz7dICyEKyS7"
-            + "v-HQ";
-    private static final String accessTokenId = "5b9fc645-2f12-4412-bdec-79c315f74c79";
-    private long tokenIssueDate;
-
-    private static final String invalidScopeResponse = "{\n"
-            + "  \"error\" : \"invalid_scope\",\n"
-            + "  \"error_description\" : \"Invalid scope: write\",\n"
-            + "  \"scope\" : \"read\"\n"
-            + "}\n";
-
-    private static final String invalidCredentialsResponse = "{\n"
-            + "  \"timestamp\" : \"2017-08-31T09:50:19.779+0000\",\n"
-            + "  \"status\" : 401,\n"
-            + "  \"error\" : \"Unauthorized\",\n"
-            + "  \"message\" : \"Bad credentials\",\n"
-            + "  \"path\" : \"/oauth/token\""
-            + "}";
-
-    private static final String invalidGrantTypeResponse = "{\n"
-            + "  \"error\" : \"invalid_client\",\n"
-            + "  \"error_description\" : \"Unauthorized grant type: client_credentials\"\n"
-            + "}";
-
-    private static final String notFoundResponse = "{\n"
-            + "  \"timestamp\" : \"2017-08-31T12:00:56.274+0000\",\n"
-            + "  \"status\" : 404,\n"
-            + "  \"error\" : \"Not Found\",\n"
-            + "  \"message\" : \"Not Found\",\n"
-            + "  \"path\" : \"/oauth/token\"\n"
-            + "}\n";
 }


### PR DESCRIPTION
Use a builder pattern for OAuth2Client. This was already
informally established, but didn't take advantage of the immutibility,
instantiation checks and defaults that a builder pattern provides. Also
allow a token to be passed, to be able to reuse tokens between OAuth2
clients.

Minor changes:
- updated dependencies
- use Java 7 for possible Android compatibility