### PR TITLE
Reduce horizontal space of rows in subject component

### DIFF
--- a/src/main/webapp/app/shared/subject/subject.component.html
+++ b/src/main/webapp/app/shared/subject/subject.component.html
@@ -28,9 +28,7 @@
         <table class="table table-striped">
             <thead>
             <tr jhiSort [(predicate)]="predicate" [(ascending)]="reverse" [callback]="transition.bind(this)">
-            <th jhiSortBy="id" ><span jhiTranslate="global.field.id">ID</span><span class="fa fa-sort"></span></th>
             <th jhiSortBy="login" ><span jhiTranslate="managementPortalApp.subject.subjectId">subjectId</span><span class="fa fa-sort"></span></th>
-            <th><span jhiTranslate="managementPortalApp.subject.externalLink">External Link</span></th>
             <th jhiSortBy="externalId" ><span jhiTranslate="managementPortalApp.subject.externalId">Enternal Id</span><span class="fa fa-sort"></span></th>
             <th jhiSortBy="status" ><span jhiTranslate="managementPortalApp.subject.status.title">Status</span><span class="fa fa-sort"></span></th>
             <th *ngIf="!isProjectSpecific"><span jhiTranslate="managementPortalApp.subject.project">Project</span> <span class="fa fa-sort"></span></th>
@@ -42,12 +40,8 @@
             </thead>
             <tbody>
             <tr *ngFor="let subject of subjects ;trackBy: trackId">
-                <td>{{subject.id}}</td>
                 <td><a [routerLink]="['/subject', subject.login ]">{{subject.login}}</a></td>
-                <td>
-                    <a target="_blank" [href]=subject.externalLink>{{subject.externalLink}}</a>
-                </td>
-                <td>{{subject.externalId}}</td>
+                <td><a target="_blank" [href]=subject.externalLink>{{subject.externalId}}</a></td>
                 <td>
                     <span class="badge badge-danger" *ngIf="subject.status == 'DEACTIVATED'">DEACTIVATED</span>
                     <span class="badge badge-success" *ngIf="subject.status == 'ACTIVATED'">ACTIVATED</span>


### PR DESCRIPTION
- Make the external ID a link to the external link, rather than explicitly showing both
- Remove the id column; as we don't need to see the database id

Closes #172 