### PR TITLE
Update all references to the RADAR-CNS github repo to RADAR-base

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ManagementPortal
 
-[![Build Status](https://travis-ci.org/RADAR-CNS/ManagementPortal.svg?branch=master)](https://travis-ci.org/RADAR-CNS/ManagementPortal)
+[![Build Status](https://travis-ci.org/RADAR-base/ManagementPortal.svg?branch=master)](https://travis-ci.org/RADAR-base/ManagementPortal)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/87bb961266d3443988b52ee7aa32f100)](https://www.codacy.com/app/RADAR-CNS/ManagementPortal?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=RADAR-CNS/ManagementPortal&amp;utm_campaign=Badge_Grade)
 [![Codacy Badge](https://api.codacy.com/project/badge/Coverage/87bb961266d3443988b52ee7aa32f100)](https://www.codacy.com/app/RADAR-CNS/ManagementPortal?utm_source=github.com&utm_medium=referral&utm_content=RADAR-CNS/ManagementPortal&utm_campaign=Badge_Coverage)
 
@@ -243,14 +243,14 @@ Then run:
 For more information refer to [Using Docker and Docker-Compose][], this page also contains information on the docker-compose sub-generator (`yo jhipster:docker-compose`), which is able to generate docker configurations for one or several JHipster applications.
 ## Documentation
 
-Visit our [Github pages](https://radar-cns.github.io/ManagementPortal) site to find links to the
+Visit our [Github pages](https://radar-base.github.io/ManagementPortal) site to find links to the
 Javadoc and API docs.
 
 The pages site is published from the `gh-pages` branch, which has its own history. If you want to
 contribute to the documentation, it is probably more convenient to clone a separate copy of this
 repository for working on the `gh-pages` branch:
 ```bash
-git clone --branch gh-pages https://github.com/RADAR-CNS/ManagementPortal.git ManagementPortal-docs
+git clone --branch gh-pages https://github.com/RADAR-base/ManagementPortal.git ManagementPortal-docs
 ```
 ## Client libraries
 

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ allprojects {
     apply plugin: 'maven-publish'
     apply plugin: 'jacoco'
     apply plugin: 'com.jfrog.artifactory'
-    ext.githubRepoName = 'RADAR-CNS/ManagementPortal'
+    ext.githubRepoName = 'RADAR-base/ManagementPortal'
 
 
     ext.githubUrl = 'https://github.com/' + githubRepoName + '.git'

--- a/mp-client-publishing.txt
+++ b/mp-client-publishing.txt
@@ -6,9 +6,9 @@ apply plugin: 'maven'
 apply plugin: 'maven-publish'
 
 ext.website = 'http://radar-cns.org/'
-ext.githubRepoName = 'RADAR-CNS/ManagementPortal'
-ext.githubUrl = 'https://github.com/RADAR-CNS/ManagementPortal/tree/master/managementportal-client'
-ext.issueUrl = 'https://github.com/RADAR-CNS/ManagementPortal/issues'
+ext.githubRepoName = 'RADAR-base/ManagementPortal'
+ext.githubUrl = 'https://github.com/RADAR-base/ManagementPortal/tree/master/managementportal-client'
+ext.issueUrl = 'https://github.com/RADAR-base/ManagementPortal/issues'
 ext.description = 'Client library for ManagementPortal.'
 
 //---------------------------------------------------------------------------//

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -121,7 +121,7 @@ jhipster:
         contact-url:
         contact-email:
         license: Apache 2.0
-        license-url: https://github.com/RADAR-CNS/ManagementPortal/blob/master/LICENSE.md
+        license-url: https://github.com/RADAR-base/ManagementPortal/blob/master/LICENSE.md
     ribbon:
         display-on-active-profiles: dev
 

--- a/src/main/webapp/app/entities/oauth-client/oauth-client-dialog.component.html
+++ b/src/main/webapp/app/entities/oauth-client/oauth-client-dialog.component.html
@@ -42,7 +42,7 @@
         <div class="form-group">
             <label class="form-control-label" for="scope" jhiTranslate="managementPortalApp.oauthClient.scope">Scope</label>
             <input type="text" class="form-control" id="scope" name="scope" [(ngModel)]="scopeList" [disabled]="protectedClient" required />
-            <small id="scopeHelp" class="form-text text-muted">Comma seperated list of scopes. Scopes should have the following structure: ENTITY.OPERATION. See the <a href="https://github.com/RADAR-CNS/ManagementPortal/tree/master/radar-auth">radar-auth library documentation</a> for more information.</small>
+            <small id="scopeHelp" class="form-text text-muted">Comma seperated list of scopes. Scopes should have the following structure: ENTITY.OPERATION. See the <a href="https://github.com/RADAR-base/ManagementPortal/tree/master/radar-auth">radar-auth library documentation</a> for more information.</small>
             <div [hidden]="!(editForm.controls.scope?.dirty && editForm.controls.scope?.invalid)">
                 <small class="form-text text-danger"
                        [hidden]="!editForm.controls.scope?.errors?.required" jhiTranslate="entity.validation.required">

--- a/src/main/webapp/i18n/en/global.json
+++ b/src/main/webapp/i18n/en/global.json
@@ -147,7 +147,7 @@
         "idexists": "A new {{ entityName }} cannot already have an ID",
         "invalidsubjectstate": "A discontinued subject can not be activated"
     },
-    "footer": "For more details, read the user guide <a target=\"_blank\" href=\"https://github.com/RADAR-CNS/ManagementPortal/wiki/User-Guide\">here.</a>",
+    "footer": "For more details, read the user guide <a target=\"_blank\" href=\"https://github.com/RADAR-base/ManagementPortal/wiki/User-Guide\">here.</a>",
     "common" : {
         "showMore": " More",
         "showLess": " Less"

--- a/util/update-gh-pages-docs.sh
+++ b/util/update-gh-pages-docs.sh
@@ -15,7 +15,7 @@ cp -R managementportal-client/build/docs/javadoc $HOME/mpc-javadoc
 cd $HOME
 git config --global user.email "travis@travis-ci.org"
 git config --global user.name "travis-ci"
-git clone --quiet --branch=gh-pages https://${GH_TOKEN}@github.com/RADAR-CNS/ManagementPortal gh-pages > /dev/null
+git clone --quiet --branch=gh-pages https://${GH_TOKEN}@github.com/RADAR-base/ManagementPortal gh-pages > /dev/null
 
 cd gh-pages
 git rm -rf ./*-javadoc


### PR DESCRIPTION
We have a number of references to the Github repo throughout the project, including in the deploy script that pushes new Javadoc to the gh-pages branch. This updates those references to the new RADAR-base organization name.