### PR TITLE
Token validator init

### DIFF
--- a/radar-auth/src/main/java/org/radarcns/auth/authentication/TokenValidator.java
+++ b/radar-auth/src/main/java/org/radarcns/auth/authentication/TokenValidator.java
@@ -32,7 +32,9 @@ import org.slf4j.LoggerFactory;
 /**
  * Validates JWT token signed by the Management Portal. It is synchronized and may be used from
  * multiple threads. If the status of the public key should be checked immediately, call
- * {@link #refresh()} directly after creating this validator.
+ * {@link #refresh()} directly after creating this validator. It currently does not check this, so
+ * that the validator can be used even if a remote ManagementPortal is not reachable during
+ * construction.
  */
 public class TokenValidator {
 

--- a/radar-auth/src/main/java/org/radarcns/auth/token/AbstractRadarToken.java
+++ b/radar-auth/src/main/java/org/radarcns/auth/token/AbstractRadarToken.java
@@ -111,4 +111,39 @@ public abstract class AbstractRadarToken implements RadarToken {
         return Objects.equals(getRoles().get(projectName),
             Collections.singletonList(AuthoritiesConstants.PARTICIPANT));
     }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if (other == null || other.getClass() != getClass()) {
+            return false;
+        }
+
+        return Objects.equals(getToken(), ((AbstractRadarToken)other).getToken());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(getToken());
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "{"
+            + "scopes=" + getScopes()
+            + ", subject='" + getSubject() + '\''
+            + ", roles=" + getRoles()
+            + ", sources=" + getSources()
+            + ", authorities=" + getAuthorities()
+            + ", grantType='" + getGrantType() + '\''
+            + ", audience=" + getAudience()
+            + ", issuer='" + getIssuer() + '\''
+            + ", issuedAt=" + getIssuedAt()
+            + ", expiresAt=" + getExpiresAt()
+            + ", type='" + getType() + '\''
+            + ", token='" + getToken() + '\''
+            + '}';
+    }
 }


### PR DESCRIPTION
Initialising TokenValidator's public key in the constructor leads to an immediate error message for builds where the ManagementPortal is not ready yet. With this change, users can still trigger a validation exception after creating the object, but it is no longer triggered by default.

Also use Duration instead of long to store a duration, and use a synchronised block rather than a thread local to store the last fetch time.