### PR TITLE
Fix an issue where refreshing an access token would not update the expiry of the new refresh token.

### DIFF
--- a/src/main/java/org/radarcns/management/config/OAuth2ServerConfiguration.java
+++ b/src/main/java/org/radarcns/management/config/OAuth2ServerConfiguration.java
@@ -221,6 +221,7 @@ public class OAuth2ServerConfiguration {
                     .approvalStore(approvalStore())
                     .tokenStore(tokenStore())
                     .tokenEnhancer(tokenEnhancerChain)
+                    .reuseRefreshTokens(false)
                     .authenticationManager(authenticationManager);
         }
 


### PR DESCRIPTION
The `AuthorizationServerEndpointsConfigurer` was setting the `reuseRefreshTokens` property of `DefaultTokenServices` as well, and it was setting it after our own settings were applied, thereby overwriting our configuration. This causes the expiry timestamp of the new refresh token to not be updated. Effectively this means the client could not get a new refresh token.