### PR TITLE
Move privacy url to meta token

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,6 @@
     "test": "yarn run lint && karma start src/test/javascript/karma.conf.js",
     "test:watch": "karma start --watch",
     "e2e": "protractor src/test/javascript/protractor.conf.js",
-    "postinstall": "webdriver-manager update && yarn run webpack:build"
+    "postinstall": "webdriver-manager update --gecko false && yarn run webpack:build"
   }
 }

--- a/src/main/java/org/radarcns/management/domain/MetaToken.java
+++ b/src/main/java/org/radarcns/management/domain/MetaToken.java
@@ -8,6 +8,8 @@ import javax.persistence.EntityListeners;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
@@ -32,7 +34,7 @@ public class MetaToken extends AbstractEntity {
     // probability-of-collision-with-randomly-generated-id
     // Current length of tokenName is 12. If we think there might be collision we can increase
     // the length.
-    public static final int SHORT_ID_LENGTH = 12;
+    private static final int SHORT_ID_LENGTH = 12;
 
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "sequenceGenerator")
@@ -52,6 +54,11 @@ public class MetaToken extends AbstractEntity {
 
     @Column(name = "expiry_date")
     private Instant expiryDate = null;
+
+    @ManyToOne
+    @JoinColumn(name = "subject_id")
+    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+    private Subject subject;
 
     /**
      * Meta token constructor.
@@ -107,6 +114,15 @@ public class MetaToken extends AbstractEntity {
         return this;
     }
 
+    public Subject getSubject() {
+        return subject;
+    }
+
+    public MetaToken subject(Subject subject) {
+        this.subject = subject;
+        return this;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -116,8 +132,10 @@ public class MetaToken extends AbstractEntity {
             return false;
         }
         MetaToken metaToken = (MetaToken) o;
-        return Objects.equals(id, metaToken.id) && Objects.equals(tokenName, metaToken.tokenName)
-            && Objects.equals(token, metaToken.token) && Objects.equals(fetched, metaToken.fetched)
+        return Objects.equals(id, metaToken.id)
+            && Objects.equals(tokenName, metaToken.tokenName)
+            && Objects.equals(token, metaToken.token)
+            && Objects.equals(fetched, metaToken.fetched)
             && Objects.equals(expiryDate, metaToken.expiryDate);
     }
 
@@ -129,7 +147,11 @@ public class MetaToken extends AbstractEntity {
 
     @Override
     public String toString() {
-        return "MetaToken{" + "id=" + id + ", tokenName='" + tokenName + '\'' + ", token='" + token
-            + '\'' + ", fetched=" + fetched + ", expiryDate=" + expiryDate + '}';
+        return "MetaToken{" + "id=" + id
+                + ", tokenName='" + tokenName
+                + ", token='" + token
+                + ", fetched=" + fetched
+                + ", expiryDate=" + expiryDate
+                +", subject=" + subject + '}';
     }
 }

--- a/src/main/java/org/radarcns/management/domain/MetaToken.java
+++ b/src/main/java/org/radarcns/management/domain/MetaToken.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EntityListeners;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -55,7 +56,7 @@ public class MetaToken extends AbstractEntity {
     @Column(name = "expiry_date")
     private Instant expiryDate = null;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "subject_id")
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private Subject subject;

--- a/src/main/java/org/radarcns/management/domain/MetaToken.java
+++ b/src/main/java/org/radarcns/management/domain/MetaToken.java
@@ -153,6 +153,6 @@ public class MetaToken extends AbstractEntity {
                 + ", token='" + token
                 + ", fetched=" + fetched
                 + ", expiryDate=" + expiryDate
-                +", subject=" + subject + '}';
+                + ", subject=" + subject + '}';
     }
 }

--- a/src/main/java/org/radarcns/management/service/MetaTokenService.java
+++ b/src/main/java/org/radarcns/management/service/MetaTokenService.java
@@ -43,6 +43,9 @@ public class MetaTokenService {
     @Autowired
     private ManagementPortalProperties managementPortalProperties;
 
+    @Autowired
+    private SubjectService subjectService;
+
     /**
      * Save a metaToken.
      *
@@ -69,7 +72,8 @@ public class MetaTokenService {
         if (!fetchedToken.isFetched() && Instant.now().isBefore(fetchedToken.getExpiryDate())) {
             // create response
             TokenDTO result = new TokenDTO(fetchedToken.getToken(),
-                    new URL(managementPortalProperties.getCommon().getBaseUrl()));
+                    new URL(managementPortalProperties.getCommon().getBaseUrl()),
+                    subjectService.getPrivacyPolicyUrl(fetchedToken.getSubject()));
             // change fetched status to true.
             fetchedToken.fetched(true);
             save(fetchedToken);

--- a/src/main/java/org/radarcns/management/service/MetaTokenService.java
+++ b/src/main/java/org/radarcns/management/service/MetaTokenService.java
@@ -12,6 +12,7 @@ import javax.validation.ConstraintViolationException;
 
 import org.radarcns.management.config.ManagementPortalProperties;
 import org.radarcns.management.domain.MetaToken;
+import org.radarcns.management.domain.Subject;
 import org.radarcns.management.repository.MetaTokenRepository;
 import org.radarcns.management.service.dto.TokenDTO;
 import org.radarcns.management.web.rest.errors.RequestGoneException;
@@ -105,17 +106,19 @@ public class MetaTokenService {
      * If a collision is detection, we try to save the token with a new tokenName
      * @return an unique token
      */
-    public MetaToken saveUniqueToken(String token, Boolean fetched, Instant expiryTime) {
+    public MetaToken saveUniqueToken(Subject subject, String token, Boolean fetched, Instant
+            expiryTime) {
         MetaToken metaToken = new MetaToken()
                 .token(token)
                 .fetched(fetched)
-                .expiryDate(expiryTime);
+                .expiryDate(expiryTime)
+                .subject(subject);
 
         try {
             return metaTokenRepository.save(metaToken);
         } catch (ConstraintViolationException e) {
             log.warn("Unique constraint violation catched... Trying to save with new tokenName");
-            return saveUniqueToken(token, fetched, expiryTime);
+            return saveUniqueToken(subject, token, fetched, expiryTime);
         }
 
     }

--- a/src/main/java/org/radarcns/management/service/OAuthClientService.java
+++ b/src/main/java/org/radarcns/management/service/OAuthClientService.java
@@ -1,9 +1,7 @@
 package org.radarcns.management.service;
 
-import static org.radarcns.management.service.dto.ProjectDTO.PRIVACY_POLICY_URL;
 import static org.radarcns.management.web.rest.MetaTokenResource.DEFAULT_META_TOKEN_TIMEOUT;
 import static org.radarcns.management.web.rest.errors.EntityName.OAUTH_CLIENT;
-import static org.radarcns.management.web.rest.errors.ErrorConstants.ERR_NO_VALID_PRIVACY_POLICY_URL_CONFIGURED;
 import static org.springframework.security.oauth2.common.util.OAuth2Utils.GRANT_TYPE;
 
 import java.net.MalformedURLException;

--- a/src/main/java/org/radarcns/management/service/OAuthClientService.java
+++ b/src/main/java/org/radarcns/management/service/OAuthClientService.java
@@ -206,8 +206,7 @@ public class OAuthClientService {
             // create complete uri string
             String tokenUrl = baseUrl + ResourceUriService.getUri(metaToken).getPath();
             // create response
-            return new ClientPairInfoDTO(metaToken.getTokenName(), new URL(tokenUrl),
-                    getPrivacyPolicyUrl(subject));
+            return new ClientPairInfoDTO(metaToken.getTokenName(), new URL(tokenUrl));
         } else {
             throw new InvalidStateException("Could not create a valid token", OAUTH_CLIENT,
                 "error.couldNotCreateToken");
@@ -215,36 +214,7 @@ public class OAuthClientService {
     }
 
 
-    /**
-     * Gets relevant privacy-policy-url for this subject.
-     * <p>
-     *     If the active project of the subject has a valid privacy-policy-url returns that url.
-     *     Otherwise, it loads the default URL from ManagementPortal configurations that is
-     *     general.
-     * </p>
-     * @param subject to get relevant policy url
-     * @return URL of privacy policy for this token
-     */
-    private URL getPrivacyPolicyUrl(Subject subject) {
 
-        // load default url from config
-        String policyUrl = subject.getActiveProject()
-                .map(p -> p.getAttributes().get(PRIVACY_POLICY_URL))
-                .filter(u -> u != null && !u.isEmpty())
-                .orElse(managementPortalProperties.getCommon().getPrivacyPolicyUrl());
-
-        try {
-            return new URL(policyUrl);
-        } catch (MalformedURLException e) {
-            Map<String, String> params = new HashMap<>();
-            params.put("url" , policyUrl);
-            params.put("message" , e.getMessage());
-            throw new InvalidStateException("No valid privacy-policy Url configured. Please "
-                    + "verify your project's privacy-policy url and/or general url config",
-                OAUTH_CLIENT, ERR_NO_VALID_PRIVACY_POLICY_URL_CONFIGURED,
-                params);
-        }
-    }
 
     /**
      * Gets the meta-token timeout from config file. If the config is not mentioned or in wrong

--- a/src/main/java/org/radarcns/management/service/OAuthClientService.java
+++ b/src/main/java/org/radarcns/management/service/OAuthClientService.java
@@ -197,7 +197,7 @@ public class OAuthClientService {
                     details.getScope(), details.getResourceIds());
         // tokenName should be generated
         MetaToken metaToken = metaTokenService
-                .saveUniqueToken(token.getRefreshToken().getValue(), false,
+                .saveUniqueToken(subject, token.getRefreshToken().getValue(), false,
                 Instant.now().plus(getMetaTokenTimeout()));
 
         if (metaToken.getId() != null && metaToken.getTokenName() != null) {

--- a/src/main/java/org/radarcns/management/service/dto/ClientPairInfoDTO.java
+++ b/src/main/java/org/radarcns/management/service/dto/ClientPairInfoDTO.java
@@ -12,20 +12,18 @@ public class ClientPairInfoDTO {
 
     private final URL tokenUrl;
 
-    private final URL privacyPolicyUrl;
 
     /**
      * Initialize with the given refresh token.
      * @param tokenName the refresh token
      * @param tokenUrl the refresh token
      */
-    public ClientPairInfoDTO(String tokenName, URL tokenUrl, URL privacyPolicyUrl) {
+    public ClientPairInfoDTO(String tokenName, URL tokenUrl) {
         if (tokenUrl == null) {
             throw new IllegalArgumentException("tokenUrl can not be null");
         }
         this.tokenName = tokenName;
         this.tokenUrl = tokenUrl;
-        this.privacyPolicyUrl = privacyPolicyUrl;
     }
 
     public String getTokenName() {
@@ -34,10 +32,6 @@ public class ClientPairInfoDTO {
 
     public URL getTokenUrl() {
         return tokenUrl;
-    }
-
-    public URL getPrivacyPolicyUrl() {
-        return privacyPolicyUrl;
     }
 
     @Override
@@ -49,14 +43,14 @@ public class ClientPairInfoDTO {
             return false;
         }
         ClientPairInfoDTO that = (ClientPairInfoDTO) o;
-        return Objects.equals(tokenName, that.tokenName) && Objects.equals(tokenUrl, that.tokenUrl)
-            && Objects.equals(privacyPolicyUrl, that.privacyPolicyUrl);
+        return Objects.equals(tokenName, that.tokenName)
+                && Objects.equals(tokenUrl, that.tokenUrl);
     }
 
     @Override
     public int hashCode() {
 
-        return Objects.hash(tokenName, tokenUrl, privacyPolicyUrl);
+        return Objects.hash(tokenName, tokenUrl);
     }
 
     @Override

--- a/src/main/java/org/radarcns/management/service/dto/TokenDTO.java
+++ b/src/main/java/org/radarcns/management/service/dto/TokenDTO.java
@@ -8,9 +8,12 @@ public class TokenDTO {
 
     private final URL baseUrl;
 
-    public TokenDTO(String refreshToken, URL baseUrl) {
+    private final URL privacyPolicyUrl;
+
+    public TokenDTO(String refreshToken, URL baseUrl, URL privacyPolicyUrl) {
         this.refreshToken = refreshToken;
         this.baseUrl = baseUrl;
+        this.privacyPolicyUrl = privacyPolicyUrl;
     }
 
     public String getRefreshToken() {
@@ -19,6 +22,10 @@ public class TokenDTO {
 
     public URL getBaseUrl() {
         return baseUrl;
+    }
+
+    public URL getPrivacyPolicyUrl() {
+        return privacyPolicyUrl;
     }
 
     @Override
@@ -30,18 +37,23 @@ public class TokenDTO {
             return false;
         }
         TokenDTO that = (TokenDTO) o;
-        return Objects.equals(refreshToken, that.refreshToken) && Objects
-            .equals(baseUrl, that.baseUrl);
+        return Objects.equals(refreshToken, that.refreshToken)
+                && Objects.equals(baseUrl, that.baseUrl)
+                && Objects.equals(privacyPolicyUrl, that.privacyPolicyUrl);
     }
 
     @Override
     public int hashCode() {
 
-        return Objects.hash(refreshToken, baseUrl);
+        return Objects.hash(refreshToken, baseUrl, privacyPolicyUrl);
     }
 
     @Override
     public String toString() {
-        return "TokenDTO{" + "refreshToken='" + refreshToken + '\'' + ", baseUrl=" + baseUrl + '}';
+        return "TokenDTO{"
+                + "refreshToken='" + refreshToken
+                + ", baseUrl=" + baseUrl
+                + ", privacyPolicyUrl=" + privacyPolicyUrl
+                + '}';
     }
 }

--- a/src/main/java/org/radarcns/management/service/dto/TokenDTO.java
+++ b/src/main/java/org/radarcns/management/service/dto/TokenDTO.java
@@ -10,6 +10,13 @@ public class TokenDTO {
 
     private final URL privacyPolicyUrl;
 
+    /**
+     * Create a meta-token using refreshToken, baseUrl of platform, and privacyPolicyURL for this
+     * token.
+     * @param refreshToken refreshToken.
+     * @param baseUrl baseUrl of the platform
+     * @param privacyPolicyUrl privacyPolicyUrl for this token.
+     */
     public TokenDTO(String refreshToken, URL baseUrl, URL privacyPolicyUrl) {
         this.refreshToken = refreshToken;
         this.baseUrl = baseUrl;

--- a/src/main/resources/config/liquibase/changelog/20180813173100_add_subject_to_meta_token.xml
+++ b/src/main/resources/config/liquibase/changelog/20180813173100_add_subject_to_meta_token.xml
@@ -1,0 +1,23 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd
+                   http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+    <!-- Add a subject to meta-token -->
+    <changeSet author="nivethika@thehyve.nl" id="20180813173100-1">
+        <addColumn tableName="radar_meta_token">
+            <column name="subject_id" type="bigint">
+            </column>
+        </addColumn>
+        <addForeignKeyConstraint baseColumnNames="subject_id"
+                                 baseTableName="radar_meta_token"
+                                 constraintName="fk_token_subject_id"
+                                 referencedColumnNames="id"
+                                 referencedTableName="subject"/>
+        <addColumn tableName="radar_meta_token_aud">
+            <column name="subject_id" type="BIGINT"/>
+            <column name="subject_mod" type="BOOLEAN"/>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -29,5 +29,6 @@
     <include file="classpath:config/liquibase/changelog/20180711141300_drop_project_admin.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20180313103735_enable_envers_revisions.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20180724105800_add_radar-meta_token.xml" relativeToChangelogFile="false"/>
+    <include file="classpath:config/liquibase/changelog/20180813173100_add_subject_to_meta_token.xml" relativeToChangelogFile="false"/>
     <!-- jhipster-needle-liquibase-add-constraints-changelog - JHipster will add liquibase constraints changelogs here -->
 </databaseChangeLog>

--- a/src/main/webapp/app/shared/subject/subject-pair-dialog.component.ts
+++ b/src/main/webapp/app/shared/subject/subject-pair-dialog.component.ts
@@ -57,7 +57,7 @@ export class SubjectPairDialogComponent implements OnInit {
         if (this.selectedClient != null) {
             this.oauthClientPairInfoService.get(this.selectedClient, this.subject).subscribe(
                 (res) => {
-                    this.oauthClientPairInfo = res.text();
+                    this.oauthClientPairInfo = res.json().tokenUrl;
                     this.showQRCode = true;
                 });
         }
@@ -65,6 +65,7 @@ export class SubjectPairDialogComponent implements OnInit {
             this.showQRCode = false;
             this.oauthClientPairInfo = "";
         }
+
     }
 
 

--- a/src/test/bash/run-e2e.sh
+++ b/src/test/bash/run-e2e.sh
@@ -4,7 +4,7 @@
 if [ -z $TRAVIS_TAG ]
 then
   echo "Running e2e tests"
-  ./node_modules/protractor/bin/webdriver-manager update
+  ls -al node_modules/webdriver-manager/selenium/
   yarn e2e
 else
   echo "Skipping e2e tests on tag builds"

--- a/src/test/java/org/radarcns/management/service/MetaTokenServiceTest.java
+++ b/src/test/java/org/radarcns/management/service/MetaTokenServiceTest.java
@@ -44,7 +44,6 @@ public class MetaTokenServiceTest {
     @Before
     public void setUp() {
         User user = createEntity();
-
         subject = new Subject()
                 .user(user);
 
@@ -110,7 +109,8 @@ public class MetaTokenServiceTest {
         MetaToken token = new MetaToken()
                 .fetched(true)
                 .tokenName("something")
-                .expiryDate(Instant.now().plus(Duration.ofHours(1)));
+                .expiryDate(Instant.now().plus(Duration.ofHours(1)))
+                .subject(subject);
 
         MetaToken saved = metaTokenService.save(token);
         assertNotNull(saved.getId());
@@ -127,7 +127,8 @@ public class MetaTokenServiceTest {
         MetaToken token = new MetaToken()
                 .fetched(false)
                 .tokenName("somethingelse")
-                .expiryDate(Instant.now().minus(Duration.ofHours(1)));
+                .expiryDate(Instant.now().minus(Duration.ofHours(1)))
+                .subject(subject);
 
         MetaToken saved = metaTokenService.save(token);
 

--- a/src/test/java/org/radarcns/management/service/MetaTokenServiceTest.java
+++ b/src/test/java/org/radarcns/management/service/MetaTokenServiceTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.radarcns.management.service.UserServiceIntTest.createEntity;
 
 import java.net.MalformedURLException;
 import java.time.Duration;
@@ -11,10 +12,13 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.radarcns.management.ManagementPortalTestApp;
 import org.radarcns.management.domain.MetaToken;
+import org.radarcns.management.domain.Subject;
+import org.radarcns.management.domain.User;
 import org.radarcns.management.repository.MetaTokenRepository;
 import org.radarcns.management.service.dto.TokenDTO;
 import org.radarcns.management.web.rest.errors.RadarWebApplicationException;
@@ -34,6 +38,17 @@ public class MetaTokenServiceTest {
 
     @Autowired
     private MetaTokenRepository metaTokenRepository;
+
+    private Subject subject;
+
+    @Before
+    public void setUp() {
+        User user = createEntity();
+
+        subject = new Subject()
+                .user(user);
+
+    }
 
     @Test
     public void testSaveThenFetchMetaToken() throws MalformedURLException {
@@ -73,7 +88,9 @@ public class MetaTokenServiceTest {
                 + "MENT.READ MEASUREMENT.UPDATE MEASUREMENT.DELETE\",\"sub\":\"admin\",\"sources"
                 + "\":[],\"grant_type\":\"password\",\"roles\":[],\"iss\":\"ManagementPortal\","
                 + "\"iat\":1532437928,\"jti\":\"dca7047b-467e-4991-9f5f-77cb108104c4\"}")
-                .expiryDate(Instant.now().plus(Duration.ofHours(1)));
+                .expiryDate(Instant.now().plus(Duration.ofHours(1)))
+                .subject(subject);
+
         MetaToken saved = metaTokenService.save(metaToken);
         assertNotNull(saved.getId());
         assertNotNull(saved.getTokenName());

--- a/src/test/java/org/radarcns/management/service/SubjectServiceTest.java
+++ b/src/test/java/org/radarcns/management/service/SubjectServiceTest.java
@@ -1,0 +1,91 @@
+package org.radarcns.management.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.radarcns.management.service.dto.ProjectDTO.PRIVACY_POLICY_URL;
+import static org.radarcns.management.service.dto.SubjectDTO.SubjectStatus.ACTIVATED;
+
+import java.net.URL;
+import java.util.Collections;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.radarcns.management.ManagementPortalTestApp;
+import org.radarcns.management.domain.Subject;
+import org.radarcns.management.service.dto.ProjectDTO;
+import org.radarcns.management.service.dto.SubjectDTO;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = ManagementPortalTestApp.class)
+@Transactional
+public class SubjectServiceTest {
+
+    public static final String DEFAULT_EXTERNAL_LINK = "AAAAAAAAAA";
+    public static final String UPDATED_EXTERNAL_LINK = "BBBBBBBBBB";
+
+    public static final String DEFAULT_ENTERNAL_ID = "AAAAAAAAAA";
+    public static final String UPDATED_ENTERNAL_ID = "BBBBBBBBBB";
+
+    public static final Boolean DEFAULT_REMOVED = false;
+    public static final Boolean UPDATED_REMOVED = true;
+
+    public static final SubjectDTO.SubjectStatus DEFAULT_STATUS = ACTIVATED;
+
+    public static final String MODEL = "App";
+    public static final String PRODUCER = "THINC-IT";
+
+    public static final String DEFAULT_PROJECT_PRIVACY_POLICY_URL =
+            "http://info.thehyve.nl/radar-cns-privacy-policy";
+
+
+    @Autowired
+    private SubjectService subjectService;
+
+    @Autowired
+    private ProjectService projectService;
+
+
+    /**
+     * Create an entity for this test.
+     *
+     * <p>This is a static method, as tests for other entities might also need it, if they test an
+     * entity which requires the current entity.</p>
+     */
+    public static SubjectDTO createEntityDTO() {
+        SubjectDTO subject = new SubjectDTO();
+        subject.setExternalLink(DEFAULT_EXTERNAL_LINK);
+        subject.setExternalId(DEFAULT_ENTERNAL_ID);
+        subject.setStatus(ACTIVATED);
+        ProjectDTO projectDto = new ProjectDTO();
+        projectDto.setId(1L);
+        projectDto.setProjectName("Radar");
+        projectDto.setLocation("SOMEWHERE");
+        projectDto.setDescription("test");
+        projectDto.setAttributes(Collections.singletonMap(PRIVACY_POLICY_URL,
+                DEFAULT_PROJECT_PRIVACY_POLICY_URL));
+        subject.setProject(projectDto);
+
+        return subject;
+    }
+
+    @Test
+    @Transactional
+    public void testGetPrivacyPolicyUrl() {
+
+        projectService.save(createEntityDTO().getProject());
+        SubjectDTO created = subjectService.createSubject(createEntityDTO());
+        assertNotNull(created.getId());
+
+        Subject subject = subjectService.findOneByLogin(created.getLogin());
+        assertNotNull(subject);
+
+        URL privacyPolicyUrl = subjectService.getPrivacyPolicyUrl(subject);
+        assertNotNull(privacyPolicyUrl);
+        assertEquals(privacyPolicyUrl.getPath(), DEFAULT_PROJECT_PRIVACY_POLICY_URL);
+
+    }
+}

--- a/src/test/java/org/radarcns/management/service/UserServiceIntTest.java
+++ b/src/test/java/org/radarcns/management/service/UserServiceIntTest.java
@@ -14,7 +14,6 @@ import org.radarcns.management.repository.filters.UserFilter;
 import org.radarcns.management.service.dto.UserDTO;
 import org.radarcns.management.service.mapper.UserMapper;
 import org.radarcns.management.service.util.RandomUtil;
-import org.radarcns.management.web.rest.UserResourceIntTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
@@ -40,6 +39,24 @@ import static org.radarcns.management.web.rest.TestUtil.commitTransactionAndStar
 @Transactional
 public class UserServiceIntTest {
 
+    public static final String DEFAULT_LOGIN = "johndoe";
+    public static final String UPDATED_LOGIN = "jhipster";
+
+    public static final String DEFAULT_PASSWORD = "passjohndoe";
+    public static final String UPDATED_PASSWORD = "passjhipster";
+
+    public static final String DEFAULT_EMAIL = "johndoe@localhost";
+    public static final String UPDATED_EMAIL = "jhipster@localhost";
+
+    public static final String DEFAULT_FIRSTNAME = "john";
+    public static final String UPDATED_FIRSTNAME = "jhipsterFirstName";
+
+    public static final String DEFAULT_LASTNAME = "doe";
+    public static final String UPDATED_LASTNAME = "jhipsterLastName";
+
+    public static final String DEFAULT_LANGKEY = "en";
+    public static final String UPDATED_LANGKEY = "fr";
+
     @Autowired
     private UserRepository userRepository;
 
@@ -52,14 +69,29 @@ public class UserServiceIntTest {
     @Autowired
     private CustomRevisionEntityRepository revisionEntityRepository;
 
-    //@Autowired
-    //private RevisionService revisionService;
-
     private UserDTO userDto;
 
     @Before
     public void setUp() {
-        userDto = userMapper.userToUserDTO(UserResourceIntTest.createEntity());
+        userDto = userMapper.userToUserDTO(createEntity());
+    }
+
+    /**
+     * Create a User.
+     *
+     * <p>This is a static method, as tests for other entities might also need it,
+     * if they test an entity which has a required relationship to the User entity.</p>
+     */
+    public static User createEntity() {
+        User user = new User();
+        user.setLogin(DEFAULT_LOGIN);
+        user.setPassword(RandomStringUtils.random(60));
+        user.setActivated(true);
+        user.setEmail(DEFAULT_EMAIL);
+        user.setFirstName(DEFAULT_FIRSTNAME);
+        user.setLastName(DEFAULT_LASTNAME);
+        user.setLangKey(DEFAULT_LANGKEY);
+        return user;
     }
 
     @Test

--- a/src/test/java/org/radarcns/management/web/rest/SubjectResourceIntTest.java
+++ b/src/test/java/org/radarcns/management/web/rest/SubjectResourceIntTest.java
@@ -5,6 +5,16 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.radarcns.management.service.SubjectServiceTest.DEFAULT_ENTERNAL_ID;
+import static org.radarcns.management.service.SubjectServiceTest.DEFAULT_EXTERNAL_LINK;
+import static org.radarcns.management.service.SubjectServiceTest.DEFAULT_REMOVED;
+import static org.radarcns.management.service.SubjectServiceTest.DEFAULT_STATUS;
+import static org.radarcns.management.service.SubjectServiceTest.MODEL;
+import static org.radarcns.management.service.SubjectServiceTest.PRODUCER;
+import static org.radarcns.management.service.SubjectServiceTest.UPDATED_ENTERNAL_ID;
+import static org.radarcns.management.service.SubjectServiceTest.UPDATED_EXTERNAL_LINK;
+import static org.radarcns.management.service.SubjectServiceTest.UPDATED_REMOVED;
+import static org.radarcns.management.service.SubjectServiceTest.createEntityDTO;
 import static org.radarcns.management.web.rest.TestUtil.commitTransactionAndStartNew;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -20,7 +30,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import javax.persistence.EntityManager;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import org.junit.Before;
@@ -66,21 +75,6 @@ import org.springframework.transaction.annotation.Transactional;
 @WithMockUser
 public class SubjectResourceIntTest {
 
-    private static final String DEFAULT_EXTERNAL_LINK = "AAAAAAAAAA";
-    private static final String UPDATED_EXTERNAL_LINK = "BBBBBBBBBB";
-
-    private static final String DEFAULT_ENTERNAL_ID = "AAAAAAAAAA";
-    private static final String UPDATED_ENTERNAL_ID = "BBBBBBBBBB";
-
-    private static final Boolean DEFAULT_REMOVED = false;
-    private static final Boolean UPDATED_REMOVED = true;
-
-    private static final SubjectDTO.SubjectStatus DEFAULT_STATUS =
-            SubjectDTO.SubjectStatus.ACTIVATED;
-
-    private static final String MODEL = "App";
-    private static final String PRODUCER = "THINC-IT";
-
     @Autowired
     private SubjectRepository subjectRepository;
 
@@ -104,9 +98,6 @@ public class SubjectResourceIntTest {
 
     @Autowired
     private ExceptionTranslator exceptionTranslator;
-
-    @Autowired
-    private EntityManager em;
 
     @Autowired
     private ProjectRepository projectRepository;
@@ -140,25 +131,6 @@ public class SubjectResourceIntTest {
                 .defaultRequest(get("/").with(OAuthHelper.bearerToken())).build();
     }
 
-    /**
-     * Create an entity for this test.
-     *
-     * <p>This is a static method, as tests for other entities might also need it, if they test an
-     * entity which requires the current entity.</p>
-     */
-    public static SubjectDTO createEntityDTO(EntityManager em) {
-        SubjectDTO subject = new SubjectDTO();
-        subject.setExternalLink(DEFAULT_EXTERNAL_LINK);
-        subject.setExternalId(DEFAULT_ENTERNAL_ID);
-        subject.setStatus(SubjectDTO.SubjectStatus.ACTIVATED);
-        ProjectDTO projectDto = new ProjectDTO();
-        projectDto.setId(1L);
-        projectDto.setProjectName("Radar");
-        projectDto.setLocation("SOMEWHERE");
-        projectDto.setDescription("test");
-        subject.setProject(projectDto);
-        return subject;
-    }
 
     @Test
     @Transactional
@@ -166,7 +138,7 @@ public class SubjectResourceIntTest {
         final int databaseSizeBeforeCreate = subjectRepository.findAll().size();
 
         // Create the Subject
-        SubjectDTO subjectDto = createEntityDTO(em);
+        SubjectDTO subjectDto = createEntityDTO();
         restSubjectMockMvc.perform(post("/api/subjects")
                 .contentType(TestUtil.APPLICATION_JSON_UTF8)
                 .content(TestUtil.convertObjectToJsonBytes(subjectDto)))
@@ -186,7 +158,7 @@ public class SubjectResourceIntTest {
     @Transactional
     public void createSubjectWithExistingId() throws Exception {
         // Create a Subject
-        SubjectDTO subjectDto = subjectService.createSubject(createEntityDTO(em));
+        SubjectDTO subjectDto = subjectService.createSubject(createEntityDTO());
         final int databaseSizeBeforeCreate = subjectRepository.findAll().size();
 
         // An entity with an existing ID cannot be created, so this API call must fail
@@ -204,7 +176,7 @@ public class SubjectResourceIntTest {
     @Transactional
     public void getAllSubjects() throws Exception {
         // Initialize the database
-        SubjectDTO subjectDto = subjectService.createSubject(createEntityDTO(em));
+        SubjectDTO subjectDto = subjectService.createSubject(createEntityDTO());
 
         // Get all the subjectList
         restSubjectMockMvc.perform(get("/api/subjects?sort=id,desc"))
@@ -220,7 +192,7 @@ public class SubjectResourceIntTest {
     @Transactional
     public void getSubject() throws Exception {
         // Initialize the database
-        SubjectDTO subjectDto = subjectService.createSubject(createEntityDTO(em));
+        SubjectDTO subjectDto = subjectService.createSubject(createEntityDTO());
 
         // Get the subject
         restSubjectMockMvc.perform(get("/api/subjects/{login}", subjectDto.getLogin()))
@@ -244,7 +216,7 @@ public class SubjectResourceIntTest {
     @Transactional
     public void updateSubject() throws Exception {
         // Initialize the database
-        SubjectDTO subjectDto = subjectService.createSubject(createEntityDTO(em));
+        SubjectDTO subjectDto = subjectService.createSubject(createEntityDTO());
         final int databaseSizeBeforeUpdate = subjectRepository.findAll().size();
 
         // Update the subject
@@ -273,7 +245,7 @@ public class SubjectResourceIntTest {
     @Transactional
     public void updateSubjectWithNewProject() throws Exception {
         // Initialize the database
-        SubjectDTO subjectDto = subjectService.createSubject(createEntityDTO(em));
+        SubjectDTO subjectDto = subjectService.createSubject(createEntityDTO());
         final int databaseSizeBeforeUpdate = subjectRepository.findAll().size();
 
         // Update the subject
@@ -313,7 +285,7 @@ public class SubjectResourceIntTest {
         final int databaseSizeBeforeUpdate = subjectRepository.findAll().size();
 
         // Create the Subject
-        SubjectDTO subjectDto = createEntityDTO(em);
+        SubjectDTO subjectDto = createEntityDTO();
 
         // If the entity doesn't have an ID, it will be created instead of just being updated
         restSubjectMockMvc.perform(put("/api/subjects")
@@ -330,7 +302,7 @@ public class SubjectResourceIntTest {
     @Transactional
     public void deleteSubject() throws Exception {
         // Initialize the database
-        SubjectDTO subjectDto = subjectService.createSubject(createEntityDTO(em));
+        SubjectDTO subjectDto = subjectService.createSubject(createEntityDTO());
         final int databaseSizeBeforeDelete = subjectRepository.findAll().size();
 
         // Get the subject
@@ -356,7 +328,7 @@ public class SubjectResourceIntTest {
         final int databaseSizeBeforeCreate = subjectRepository.findAll().size();
 
         // Create the Subject
-        SubjectDTO subjectDto = createEntityDTO(em);
+        SubjectDTO subjectDto = createEntityDTO();
         restSubjectMockMvc.perform(post("/api/subjects")
                 .contentType(TestUtil.APPLICATION_JSON_UTF8)
                 .content(TestUtil.convertObjectToJsonBytes(subjectDto)))
@@ -393,7 +365,7 @@ public class SubjectResourceIntTest {
         final int databaseSizeBeforeCreate = subjectRepository.findAll().size();
 
         // Create the Subject
-        SubjectDTO subjectDto = createEntityDTO(em);
+        SubjectDTO subjectDto = createEntityDTO();
         restSubjectMockMvc.perform(post("/api/subjects")
                 .contentType(TestUtil.APPLICATION_JSON_UTF8)
                 .content(TestUtil.convertObjectToJsonBytes(subjectDto)))
@@ -436,7 +408,7 @@ public class SubjectResourceIntTest {
     @Transactional
     public void getSubjectSources() throws Exception {
         // Initialize the database
-        SubjectDTO subjectDtoToCreate = createEntityDTO(em);
+        SubjectDTO subjectDtoToCreate = createEntityDTO();
         SourceDTO createdSource = sourceService.save(createSource());
         MinimalSourceDetailsDTO sourceDto = new MinimalSourceDetailsDTO()
                 .id(createdSource.getId())
@@ -463,7 +435,7 @@ public class SubjectResourceIntTest {
     @Transactional
     public void getSubjectSourcesWithQueryParam() throws Exception {
         // Initialize the database
-        SubjectDTO subjectDtoToCreate = createEntityDTO(em);
+        SubjectDTO subjectDtoToCreate = createEntityDTO();
         SourceDTO createdSource = sourceService.save(createSource());
         MinimalSourceDetailsDTO sourceDto = new MinimalSourceDetailsDTO()
                 .id(createdSource.getId())
@@ -492,7 +464,7 @@ public class SubjectResourceIntTest {
     @Transactional
     public void getInactiveSubjectSourcesWithQueryParam() throws Exception {
         // Initialize the database
-        SubjectDTO subjectDtoToCreate = createEntityDTO(em);
+        SubjectDTO subjectDtoToCreate = createEntityDTO();
         SourceDTO createdSource = sourceService.save(createSource());
         MinimalSourceDetailsDTO sourceDto = new MinimalSourceDetailsDTO()
                 .id(createdSource.getId())
@@ -576,7 +548,7 @@ public class SubjectResourceIntTest {
         final int databaseSizeBeforeCreate = subjectRepository.findAll().size();
 
         // Create the Subject
-        SubjectDTO subjectDto = createEntityDTO(em);
+        SubjectDTO subjectDto = createEntityDTO();
         restSubjectMockMvc.perform(post("/api/subjects")
                 .contentType(TestUtil.APPLICATION_JSON_UTF8)
                 .content(TestUtil.convertObjectToJsonBytes(subjectDto)))

--- a/src/test/java/org/radarcns/management/web/rest/UserResourceIntTest.java
+++ b/src/test/java/org/radarcns/management/web/rest/UserResourceIntTest.java
@@ -37,6 +37,19 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.hasItem;
+import static org.radarcns.management.service.UserServiceIntTest.DEFAULT_EMAIL;
+import static org.radarcns.management.service.UserServiceIntTest.DEFAULT_FIRSTNAME;
+import static org.radarcns.management.service.UserServiceIntTest.DEFAULT_LANGKEY;
+import static org.radarcns.management.service.UserServiceIntTest.DEFAULT_LASTNAME;
+import static org.radarcns.management.service.UserServiceIntTest.DEFAULT_LOGIN;
+import static org.radarcns.management.service.UserServiceIntTest.DEFAULT_PASSWORD;
+import static org.radarcns.management.service.UserServiceIntTest.UPDATED_EMAIL;
+import static org.radarcns.management.service.UserServiceIntTest.UPDATED_FIRSTNAME;
+import static org.radarcns.management.service.UserServiceIntTest.UPDATED_LANGKEY;
+import static org.radarcns.management.service.UserServiceIntTest.UPDATED_LASTNAME;
+import static org.radarcns.management.service.UserServiceIntTest.UPDATED_LOGIN;
+import static org.radarcns.management.service.UserServiceIntTest.UPDATED_PASSWORD;
+import static org.radarcns.management.service.UserServiceIntTest.createEntity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -54,24 +67,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest(classes = ManagementPortalTestApp.class)
 @WithMockUser
 public class UserResourceIntTest {
-
-    private static final String DEFAULT_LOGIN = "johndoe";
-    private static final String UPDATED_LOGIN = "jhipster";
-
-    private static final String DEFAULT_PASSWORD = "passjohndoe";
-    private static final String UPDATED_PASSWORD = "passjhipster";
-
-    private static final String DEFAULT_EMAIL = "johndoe@localhost";
-    private static final String UPDATED_EMAIL = "jhipster@localhost";
-
-    private static final String DEFAULT_FIRSTNAME = "john";
-    private static final String UPDATED_FIRSTNAME = "jhipsterFirstName";
-
-    private static final String DEFAULT_LASTNAME = "doe";
-    private static final String UPDATED_LASTNAME = "jhipsterLastName";
-
-    private static final String DEFAULT_LANGKEY = "en";
-    private static final String UPDATED_LANGKEY = "fr";
 
     @Autowired
     private UserRepository userRepository;
@@ -122,23 +117,7 @@ public class UserResourceIntTest {
                 .defaultRequest(get("/").with(OAuthHelper.bearerToken())).build();
     }
 
-    /**
-     * Create a User.
-     *
-     * <p>This is a static method, as tests for other entities might also need it,
-     * if they test an entity which has a required relationship to the User entity.</p>
-     */
-    public static User createEntity() {
-        User user = new User();
-        user.setLogin(DEFAULT_LOGIN);
-        user.setPassword(RandomStringUtils.random(60));
-        user.setActivated(true);
-        user.setEmail(DEFAULT_EMAIL);
-        user.setFirstName(DEFAULT_FIRSTNAME);
-        user.setLastName(DEFAULT_LASTNAME);
-        user.setLangKey(DEFAULT_LANGKEY);
-        return user;
-    }
+
 
     @Before
     public void initTest() {


### PR DESCRIPTION
- Move privacy-policy-url to meta-token.
- This stores owning subject of the token.