### PR TITLE
Streamline Dockerfile caching

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+build
+out
+radar-auth/build
+radar-auth/out
+radar-auth/src/test
+.idea
+.gradle
+.git
+node_modules
+oauth-client-util/build
+oauth-client-util/out
+oauth-client-util/src/test
+src/test/java
+src/gatling

--- a/build.gradle
+++ b/build.gradle
@@ -526,3 +526,9 @@ artifactory {
 artifactoryPublish {
     publications('ManagementPortalPublication')
 }
+
+task downloadDependencies {
+    description "Pre-downloads dependencies"
+    configurations.compileClasspath.files
+    configurations.runtimeClasspath.files
+}

--- a/gradle/profile_prod.gradle
+++ b/gradle/profile_prod.gradle
@@ -8,10 +8,6 @@ ext {
     swaggerTargetFolder = "managementportal-client"
 }
 
-dependencies {
-
-}
-
 def profiles = 'prod'
 if (project.hasProperty('no-liquibase')) {
     profiles += ',no-liquibase'
@@ -44,7 +40,7 @@ processResources {
             it.replace('#spring.profiles.active#', profiles)
         }
         filter {
-            it.replace('#project.version#', version)
+            it.replace('#project.version#', version.toString())
         }
     }
 }


### PR DESCRIPTION
Does not invalidate the cache as often, making for faster builds. Also use a much smaller context by excluding already built files.

Note that building web part of the system is still ridiculously slow, so the `bootRepackage` step still takes up a significant portion of the build time.

Fixes https://github.com/RADAR-base/ManagementPortal/issues/301.