### PR TITLE
Delete inactive subject before deleting the user

### DIFF
--- a/src/main/java/org/radarcns/management/service/SubjectService.java
+++ b/src/main/java/org/radarcns/management/service/SubjectService.java
@@ -11,6 +11,7 @@ import static org.radarcns.management.web.rest.errors.ErrorConstants.ERR_SUBJECT
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.time.Period;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.Collections;
@@ -36,6 +37,7 @@ import org.radarcns.management.repository.AuthorityRepository;
 import org.radarcns.management.repository.RoleRepository;
 import org.radarcns.management.repository.SourceRepository;
 import org.radarcns.management.repository.SubjectRepository;
+import org.radarcns.management.repository.UserRepository;
 import org.radarcns.management.service.dto.MinimalSourceDetailsDTO;
 import org.radarcns.management.service.dto.SubjectDTO;
 import org.radarcns.management.service.dto.UserDTO;
@@ -54,6 +56,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.history.Revisions;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -97,6 +100,8 @@ public class SubjectService {
     @Autowired
     private ManagementPortalProperties managementPortalProperties;
 
+    @Autowired
+    private UserRepository userRepository;
 
     /**
      * Create a new subject.
@@ -489,5 +494,29 @@ public class SubjectService {
                     OAUTH_CLIENT, ERR_NO_VALID_PRIVACY_POLICY_URL_CONFIGURED,
                     params);
         }
+    }
+
+    /**
+     * Not activated users should be automatically deleted after 3 days. <p> This is scheduled to
+     * get fired everyday, at midnight. Preferably we do this scan before
+     * {@link UserService#removeNotActivatedUsers()}, since this will remove the not activated
+     * user tied to the subject as well.</p>
+     */
+    @Scheduled(cron = "0 0 0 * * ?")
+    public void removeNotActivatedSubjects() {
+        log.info("Scheduled scan for expired subject accounts starting now");
+        ZonedDateTime cutoff = ZonedDateTime.now().minus(Period.ofDays(3));
+
+        // first delete non-activated users related to subjects
+        userRepository.findAllByActivated(false).stream()
+                .filter(user -> revisionService.getAuditInfo(user).getCreatedAt().isBefore(cutoff))
+                .map(User::getLogin)
+                .map(subjectRepository::findOneWithEagerBySubjectLogin)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .forEach(subject -> {
+                    log.info("Deleting not activated subject after 3 days: {}", subject);
+                    subjectRepository.delete(subject);
+                });
     }
 }

--- a/src/test/java/org/radarcns/management/service/SubjectServiceTest.java
+++ b/src/test/java/org/radarcns/management/service/SubjectServiceTest.java
@@ -1,23 +1,38 @@
 package org.radarcns.management.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.radarcns.management.service.dto.ProjectDTO.PRIVACY_POLICY_URL;
 import static org.radarcns.management.service.dto.SubjectDTO.SubjectStatus.ACTIVATED;
+import static org.radarcns.management.web.rest.TestUtil.commitTransactionAndStartNew;
 
 import java.net.URL;
+import java.time.Period;
+import java.time.ZonedDateTime;
 import java.util.Collections;
+import java.util.Date;
+import java.util.List;
 
+import org.hibernate.envers.AuditReader;
+import org.hibernate.envers.query.AuditEntity;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.radarcns.management.ManagementPortalTestApp;
 import org.radarcns.management.domain.Subject;
+import org.radarcns.management.domain.User;
+import org.radarcns.management.domain.audit.CustomRevisionEntity;
+import org.radarcns.management.repository.SubjectRepository;
+import org.radarcns.management.repository.UserRepository;
 import org.radarcns.management.service.dto.ProjectDTO;
 import org.radarcns.management.service.dto.SubjectDTO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = ManagementPortalTestApp.class)
@@ -47,6 +62,15 @@ public class SubjectServiceTest {
 
     @Autowired
     private ProjectService projectService;
+
+    @Autowired
+    private SubjectRepository subjectRepository;
+
+    @Autowired
+    private RevisionService revisionService;
+
+    @Autowired
+    private UserRepository userRepository;
 
 
     /**
@@ -87,5 +111,45 @@ public class SubjectServiceTest {
         assertNotNull(privacyPolicyUrl);
         assertEquals(privacyPolicyUrl.toExternalForm(), DEFAULT_PROJECT_PRIVACY_POLICY_URL);
 
+    }
+
+    @Test
+    public void testFindNotActivatedSubjectsByCreationDateBefore() {
+        User expiredUser = UserServiceIntTest.addExpiredUser(userRepository);
+        Subject expiredSubject = new Subject();
+        expiredSubject.setUser(expiredUser);
+        subjectRepository.save(expiredSubject);
+        commitTransactionAndStartNew();
+
+        AuditReader auditReader = ((AuditReader) ReflectionTestUtils
+                .getField(revisionService, "auditReader"));
+        Object[] firstRevision = (Object[]) auditReader.createQuery()
+                .forRevisionsOfEntity(expiredUser.getClass(), false, true)
+                .add(AuditEntity.id().eq(expiredUser.getId()))
+                .add(AuditEntity.revisionNumber().minimize()
+                        .computeAggregationInInstanceContext())
+                .getSingleResult();
+        CustomRevisionEntity first = (CustomRevisionEntity) firstRevision[1];
+        // Update the timestamp of the revision so it appears to have been created 5 days ago
+        ZonedDateTime expDateTime = ZonedDateTime.now().minus(Period.ofDays(5));
+        first.setTimestamp(Date.from(expDateTime.toInstant()));
+        EntityManager entityManager = ((EntityManager) ReflectionTestUtils
+                .getField(revisionService, "entityManager"));
+        entityManager.persist(first);
+
+        // make sure when we reload the expired user we have the new created date
+        assertThat(revisionService.getAuditInfo(expiredUser).getCreatedAt()).isEqualTo(expDateTime);
+
+        // Now we know we have an 'old' user in the database, we can test our deletion method
+        int numSubjects = subjectRepository.findAll().size();
+        subjectService.removeNotActivatedSubjects();
+        List<Subject> subjects = subjectRepository.findAll();
+        // make sure have actually deleted some users, otherwise this test is pointless
+        assertThat(numSubjects - subjects.size()).isEqualTo(1);
+        // remaining users should be either activated or have a created date less then 3 days ago
+        ZonedDateTime cutoff = ZonedDateTime.now().minus(Period.ofDays(3));
+        subjects.forEach(s -> assertThat(s.getUser().getActivated() || revisionService
+                .getAuditInfo(s).getCreatedAt().isAfter(cutoff)).isTrue());
+        commitTransactionAndStartNew();
     }
 }


### PR DESCRIPTION
In the scheduled job to delete old inactive users, first delete associated subjects if they exist.

I chose not to update the general `UserService.deleteUser()` method, I think the extra safeguard of having to explicitly delete the subject rather than have a user deletion always trigger subject deletion is still a good thing. For cleaning up inactive users, we can do it automatically.

Fixes #280 