### PR TITLE
Dynamic registration improvements

### DIFF
--- a/src/main/java/org/radarcns/management/service/SubjectService.java
+++ b/src/main/java/org/radarcns/management/service/SubjectService.java
@@ -279,8 +279,6 @@ public class SubjectService {
                 }
                 // make sure there is no source available on the same name.
                 if (sourceRepository.findOneBySourceName(source.getSourceName()).isPresent()) {
-                    log.error("Cannot create a source with existing source-name {}",
-                            source.getSourceName());
                     throw new ConflictException("SourceName already in use. Cannot create a "
                         + "source with existing source-name ", SUBJECT,
                         ErrorConstants.ERR_SOURCE_NAME_EXISTS,
@@ -291,8 +289,6 @@ public class SubjectService {
                 assignedSource = source;
                 subject.getSources().add(source);
             } else {
-                log.error("A Source of SourceType with the specified producer, model and version "
-                        + "was already registered for subject login");
                 Map<String, String> errorParams = new HashMap<>();
                 errorParams.put("producer", sourceType.getProducer());
                 errorParams.put("model", sourceType.getModel());
@@ -305,7 +301,6 @@ public class SubjectService {
             }
         } else {
             // new source since sourceId == null, but canRegisterDynamically == false
-            log.error("The source type is not eligible for dynamic registration");
             Map<String, String> errorParams = new HashMap<>();
             errorParams.put("producer", sourceType.getProducer());
             errorParams.put("model", sourceType.getModel());
@@ -344,7 +339,6 @@ public class SubjectService {
 
             return sourceRepository.save(source);
         } else {
-            log.error("No source with source-id to assigned to the subject with subject-login");
             Map<String, String> errorParams = new HashMap<>();
             errorParams.put("sourceId", sourceRegistrationDto.getSourceId().toString());
             errorParams.put("subject-login", subject.getUser().getLogin());

--- a/src/main/java/org/radarcns/management/web/rest/SubjectResource.java
+++ b/src/main/java/org/radarcns/management/web/rest/SubjectResource.java
@@ -425,7 +425,8 @@ public class SubjectResource {
                         sourceDto.getSourceTypeProducer(),
                         sourceDto.getSourceTypeModel(),
                         sourceDto.getSourceTypeCatalogVersion()).getId();
-
+            // also update the sourceDto, since we pass it on to SubjectService later
+            sourceDto.setSourceTypeId(sourceTypeId);
         }
 
         // check the subject id


### PR DESCRIPTION
- Fix checks around source registration. 
- Add test case for trying to register a source without dynamic registration flag for the source type
- Remove `log.error()` statements for messages that will be printed by throwing the exception anyway

Fixes #319 