### PR TITLE
Fix forign keys violation during delete

### DIFF
--- a/src/main/java/org/radarcns/management/domain/Subject.java
+++ b/src/main/java/org/radarcns/management/domain/Subject.java
@@ -28,6 +28,7 @@ import javax.validation.constraints.NotNull;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -76,6 +77,10 @@ public class Subject extends AbstractEntity implements Serializable {
     @CollectionTable(name = "subject_metadata", joinColumns = @JoinColumn(name = "id"))
     @Cascade(CascadeType.ALL)
     private Map<String, String> attributes = new HashMap<>();
+
+    @OneToMany(mappedBy = "subject", orphanRemoval = true)
+    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+    private Set<MetaToken> metaTokens = new HashSet<>();
 
     public Long getId() {
         return id;
@@ -156,6 +161,10 @@ public class Subject extends AbstractEntity implements Serializable {
 
     public void setAttributes(Map<String, String> attributes) {
         this.attributes = attributes;
+    }
+
+    public Set<MetaToken> getMetaTokens() {
+        return metaTokens;
     }
 
     /**

--- a/src/main/java/org/radarcns/management/domain/Subject.java
+++ b/src/main/java/org/radarcns/management/domain/Subject.java
@@ -28,7 +28,6 @@ import javax.validation.constraints.NotNull;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -80,7 +79,7 @@ public class Subject extends AbstractEntity implements Serializable {
 
     @OneToMany(mappedBy = "subject", orphanRemoval = true)
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
-    private Set<MetaToken> metaTokens = new HashSet<>();
+    private final Set<MetaToken> metaTokens = new HashSet<>();
 
     public Long getId() {
         return id;

--- a/src/main/java/org/radarcns/management/repository/UserRepository.java
+++ b/src/main/java/org/radarcns/management/repository/UserRepository.java
@@ -6,8 +6,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.RepositoryDefinition;
 import org.springframework.data.repository.history.RevisionRepository;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -22,6 +24,13 @@ public interface UserRepository extends JpaRepository<User, Long>,
     Optional<User> findOneByActivationKey(String activationKey);
 
     List<User> findAllByActivated(boolean activated);
+
+    @Query("select user from User user "
+            + "left join fetch user.roles roles where "
+            + "roles.authority.name not in :authorities "
+            + "and user.activated= :activated")
+    List<User> findAllByActivatedAndAuthoritiesNot(@Param("activated") boolean activated,
+            @Param("authorities") List<String> authorities);
 
     Optional<User> findOneByResetKey(String resetKey);
 

--- a/src/main/java/org/radarcns/management/service/SubjectService.java
+++ b/src/main/java/org/radarcns/management/service/SubjectService.java
@@ -12,7 +12,6 @@ import static org.radarcns.management.web.rest.errors.ErrorConstants.ERR_SUBJECT
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.time.Period;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.Collections;
@@ -38,7 +37,6 @@ import org.radarcns.management.repository.AuthorityRepository;
 import org.radarcns.management.repository.RoleRepository;
 import org.radarcns.management.repository.SourceRepository;
 import org.radarcns.management.repository.SubjectRepository;
-import org.radarcns.management.repository.UserRepository;
 import org.radarcns.management.service.dto.MinimalSourceDetailsDTO;
 import org.radarcns.management.service.dto.SubjectDTO;
 import org.radarcns.management.service.dto.UserDTO;
@@ -57,7 +55,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.history.Revisions;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -100,9 +97,6 @@ public class SubjectService {
 
     @Autowired
     private ManagementPortalProperties managementPortalProperties;
-
-    @Autowired
-    private UserRepository userRepository;
 
     /**
      * Create a new subject.

--- a/src/main/java/org/radarcns/management/service/SubjectService.java
+++ b/src/main/java/org/radarcns/management/service/SubjectService.java
@@ -486,27 +486,4 @@ public class SubjectService {
         }
     }
 
-    /**
-     * Not activated users should be automatically deleted after 3 days. <p> This is scheduled to
-     * get fired everyday, at midnight. Preferably we do this scan before
-     * {@link UserService#removeNotActivatedUsers()}, since this will remove the not activated
-     * user tied to the subject as well.</p>
-     */
-    @Scheduled(cron = "0 0 0 * * ?")
-    public void removeNotActivatedSubjects() {
-        log.info("Scheduled scan for expired subject accounts starting now");
-        ZonedDateTime cutoff = ZonedDateTime.now().minus(Period.ofDays(3));
-
-        // first delete non-activated users related to subjects
-        userRepository.findAllByActivated(false).stream()
-                .filter(user -> revisionService.getAuditInfo(user).getCreatedAt().isBefore(cutoff))
-                .map(User::getLogin)
-                .map(subjectRepository::findOneWithEagerBySubjectLogin)
-                .filter(Optional::isPresent)
-                .map(Optional::get)
-                .forEach(subject -> {
-                    log.info("Deleting not activated subject after 3 days: {}", subject);
-                    subjectRepository.delete(subject);
-                });
-    }
 }

--- a/src/main/java/org/radarcns/management/service/UserService.java
+++ b/src/main/java/org/radarcns/management/service/UserService.java
@@ -358,7 +358,7 @@ public class UserService {
      * get fired everyday, at 01:00 (am). This is aimed at users, not subjects. So filter our
      * users with *PARTICIPANT role and perform the action.</p>
      */
-    @Scheduled(cron = "0 0 18 30 * ?")
+    @Scheduled(cron = "0 0 1 * * ?")
     public void removeNotActivatedUsers() {
         log.info("Scheduled scan for expired user accounts starting now");
         ZonedDateTime cutoff = ZonedDateTime.now().minus(Period.ofDays(3));

--- a/src/main/java/org/radarcns/management/service/mapper/SubjectMapper.java
+++ b/src/main/java/org/radarcns/management/service/mapper/SubjectMapper.java
@@ -34,10 +34,12 @@ public interface SubjectMapper {
     @Mapping(target = "user.activated", ignore = true)
     @Mapping(target = "removed", ignore = true)
     @Mapping(source = "roles" , target = "user.roles")
+    @Mapping(target = "metaTokens", ignore = true)
     Subject subjectDTOToSubject(SubjectDTO subjectDto);
 
     @Mapping(target = "user", ignore = true)
     @Mapping(target = "removed", ignore = true)
+    @Mapping(target = "metaTokens", ignore = true)
     Subject safeUpdateSubjectFromDTO(SubjectDTO subjectDto, @MappingTarget Subject subject);
 
     List<Subject> subjectDTOsToSubjects(List<SubjectDTO> subjectDtos);

--- a/src/main/resources/config/liquibase/changelog/20180824131400_add_meta_token_mod_to_subject.xml
+++ b/src/main/resources/config/liquibase/changelog/20180824131400_add_meta_token_mod_to_subject.xml
@@ -1,0 +1,13 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd
+                   http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+    <!-- Add a subject to meta-token -->
+    <changeSet author="nivethika@thehyve.nl" id="20181128141000-1">
+        <addColumn tableName="subject_aud">
+            <column name="meta_tokens_mod" type="BOOLEAN"/>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -31,5 +31,6 @@
     <include file="classpath:config/liquibase/changelog/20180724105800_add_radar-meta_token.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20180813173100_add_subject_to_meta_token.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20180824131400_add_client_id_to_meta_token.xml" relativeToChangelogFile="false"/>
+    <include file="classpath:config/liquibase/changelog/20180824131400_add_meta_token_mod_to_subject.xml" relativeToChangelogFile="false"/>
     <!-- jhipster-needle-liquibase-add-constraints-changelog - JHipster will add liquibase constraints changelogs here -->
 </databaseChangeLog>

--- a/src/main/webapp/app/admin/user-management/user-management.component.html
+++ b/src/main/webapp/app/admin/user-management/user-management.component.html
@@ -97,7 +97,10 @@
                         <button type="submit"
                                 [routerLink]="['/', { outlets: { popup: 'user-management/'+ user.login + '/delete'} }]"
                                 [replaceUrl]="true"
-                                class="btn btn-danger btn-sm" [disabled]="currentAccount.login==user.login">
+                                class="btn btn-danger btn-sm"
+                                [disabled]="currentAccount.login==user.login ||
+                                user.roles[0].authorityName=='ROLE_PARTICIPANT' ||
+                                user.roles[0].authorityName=='ROLE_INACTIVE_PARTICIPANT'">
                             <span class="fa fa-remove"></span>
                             <span class="hidden-md-down" jhiTranslate="entity.action.delete">Delete</span>
                         </button>

--- a/src/test/java/org/radarcns/management/service/SubjectServiceTest.java
+++ b/src/test/java/org/radarcns/management/service/SubjectServiceTest.java
@@ -1,38 +1,23 @@
 package org.radarcns.management.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.radarcns.management.service.dto.ProjectDTO.PRIVACY_POLICY_URL;
 import static org.radarcns.management.service.dto.SubjectDTO.SubjectStatus.ACTIVATED;
-import static org.radarcns.management.web.rest.TestUtil.commitTransactionAndStartNew;
 
 import java.net.URL;
-import java.time.Period;
-import java.time.ZonedDateTime;
 import java.util.Collections;
-import java.util.Date;
-import java.util.List;
 
-import org.hibernate.envers.AuditReader;
-import org.hibernate.envers.query.AuditEntity;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.radarcns.management.ManagementPortalTestApp;
 import org.radarcns.management.domain.Subject;
-import org.radarcns.management.domain.User;
-import org.radarcns.management.domain.audit.CustomRevisionEntity;
-import org.radarcns.management.repository.SubjectRepository;
-import org.radarcns.management.repository.UserRepository;
 import org.radarcns.management.service.dto.ProjectDTO;
 import org.radarcns.management.service.dto.SubjectDTO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.annotation.Transactional;
-
-import javax.persistence.EntityManager;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = ManagementPortalTestApp.class)
@@ -62,16 +47,6 @@ public class SubjectServiceTest {
 
     @Autowired
     private ProjectService projectService;
-
-    @Autowired
-    private SubjectRepository subjectRepository;
-
-    @Autowired
-    private RevisionService revisionService;
-
-    @Autowired
-    private UserRepository userRepository;
-
 
     /**
      * Create an entity for this test.
@@ -113,43 +88,4 @@ public class SubjectServiceTest {
 
     }
 
-    @Test
-    public void testFindNotActivatedSubjectsByCreationDateBefore() {
-        User expiredUser = UserServiceIntTest.addExpiredUser(userRepository);
-        Subject expiredSubject = new Subject();
-        expiredSubject.setUser(expiredUser);
-        subjectRepository.save(expiredSubject);
-        commitTransactionAndStartNew();
-
-        AuditReader auditReader = ((AuditReader) ReflectionTestUtils
-                .getField(revisionService, "auditReader"));
-        Object[] firstRevision = (Object[]) auditReader.createQuery()
-                .forRevisionsOfEntity(expiredUser.getClass(), false, true)
-                .add(AuditEntity.id().eq(expiredUser.getId()))
-                .add(AuditEntity.revisionNumber().minimize()
-                        .computeAggregationInInstanceContext())
-                .getSingleResult();
-        CustomRevisionEntity first = (CustomRevisionEntity) firstRevision[1];
-        // Update the timestamp of the revision so it appears to have been created 5 days ago
-        ZonedDateTime expDateTime = ZonedDateTime.now().minus(Period.ofDays(5));
-        first.setTimestamp(Date.from(expDateTime.toInstant()));
-        EntityManager entityManager = ((EntityManager) ReflectionTestUtils
-                .getField(revisionService, "entityManager"));
-        entityManager.persist(first);
-
-        // make sure when we reload the expired user we have the new created date
-        assertThat(revisionService.getAuditInfo(expiredUser).getCreatedAt()).isEqualTo(expDateTime);
-
-        // Now we know we have an 'old' user in the database, we can test our deletion method
-        int numSubjects = subjectRepository.findAll().size();
-        subjectService.removeNotActivatedSubjects();
-        List<Subject> subjects = subjectRepository.findAll();
-        // make sure have actually deleted some users, otherwise this test is pointless
-        assertThat(numSubjects - subjects.size()).isEqualTo(1);
-        // remaining users should be either activated or have a created date less then 3 days ago
-        ZonedDateTime cutoff = ZonedDateTime.now().minus(Period.ofDays(3));
-        subjects.forEach(s -> assertThat(s.getUser().getActivated() || revisionService
-                .getAuditInfo(s).getCreatedAt().isAfter(cutoff)).isTrue());
-        commitTransactionAndStartNew();
-    }
 }

--- a/src/test/java/org/radarcns/management/service/UserServiceIntTest.java
+++ b/src/test/java/org/radarcns/management/service/UserServiceIntTest.java
@@ -8,6 +8,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.radarcns.auth.config.Constants;
 import org.radarcns.management.ManagementPortalTestApp;
+import org.radarcns.management.domain.Authority;
+import org.radarcns.management.domain.Role;
 import org.radarcns.management.domain.User;
 import org.radarcns.management.domain.audit.CustomRevisionEntity;
 import org.radarcns.management.repository.CustomRevisionEntityRepository;
@@ -28,11 +30,13 @@ import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import java.time.Period;
 import java.time.ZonedDateTime;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.radarcns.auth.authorization.AuthoritiesConstants.SYS_ADMIN;
 import static org.radarcns.management.web.rest.TestUtil.commitTransactionAndStartNew;
 
 /**
@@ -239,11 +243,18 @@ public class UserServiceIntTest {
      * @return the saved object
      */
     public static User addExpiredUser(UserRepository userRepository) {
+
+        Role adminRole = new Role();
+        adminRole.setId(1L);
+        adminRole.setAuthority(new Authority(SYS_ADMIN));
+        adminRole.setProject(null);
+
         User user = new User();
         user.setLogin("expired");
         user.setEmail("expired@expired");
         user.setFirstName("ex");
         user.setLastName("pired");
+        user.setRoles(Collections.singleton(adminRole));
         user.setActivated(false);
         user.setPassword(RandomStringUtils.random(60));
         return userRepository.save(user);


### PR DESCRIPTION
- Do not remove not activated users related to subject in the cron job.
( The subjects are by default `activated`. When a subject is `discontinued` their status become inactive. If we want to delete discontinued subject, we should delete the subjects, which will perform a collective deletion of associated user)
- When the cron job is running, filter out users related to subject i.e. ( which contains PARTICIPANT or INACTIVE_PARTICIPANT role)
- Add bidirectional relationship between subject and meta-token to allow automatic removal of metatokens during subject delete. 

Closes #341 