### PR TITLE
fix limited number of source-type load in project dialog

### DIFF
--- a/src/main/java/org/radarcns/management/web/rest/SourceTypeResource.java
+++ b/src/main/java/org/radarcns/management/web/rest/SourceTypeResource.java
@@ -21,7 +21,6 @@ import javax.validation.Valid;
 
 import com.codahale.metrics.annotation.Timed;
 import io.github.jhipster.web.util.ResponseUtil;
-import io.swagger.annotations.ApiParam;
 import org.radarcns.auth.config.Constants;
 import org.radarcns.auth.exception.NotAuthorizedException;
 import org.radarcns.management.domain.SourceType;

--- a/src/main/java/org/radarcns/management/web/rest/SourceTypeResource.java
+++ b/src/main/java/org/radarcns/management/web/rest/SourceTypeResource.java
@@ -40,6 +40,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -60,8 +61,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class SourceTypeResource {
 
     private final Logger log = LoggerFactory.getLogger(SourceTypeResource.class);
-
-
 
     @Autowired
     private SourceTypeService sourceTypeService;
@@ -145,7 +144,8 @@ public class SourceTypeResource {
      */
     @GetMapping("/source-types")
     @Timed
-    public ResponseEntity<List<SourceTypeDTO>> getAllSourceTypes(@ApiParam Pageable pageable)
+    public ResponseEntity<List<SourceTypeDTO>> getAllSourceTypes(
+            @PageableDefault(page = 0, size = Integer.MAX_VALUE) Pageable pageable)
             throws NotAuthorizedException {
         checkPermission(getJWT(servletRequest), SOURCETYPE_READ);
         Page<SourceTypeDTO> page = sourceTypeService.findAll(pageable);

--- a/src/main/webapp/app/entities/project/project-dialog.component.ts
+++ b/src/main/webapp/app/entities/project/project-dialog.component.ts
@@ -32,7 +32,8 @@ export class ProjectDialogComponent implements OnInit {
             private sourceTypeService: SourceTypeService,
             private eventManager: EventManager,
     ) {
-        this.jhiLanguageService.setLocations(['project', 'projectStatus']);
+        this.jhiLanguageService.addLocation('projectStatus');
+        this.jhiLanguageService.addLocation('project')
         this.isSaving = false;
         this.authorities = ['ROLE_USER', 'ROLE_SYS_ADMIN', 'ROLE_PROJECT_ADMIN'];
         this.options = ['Work-package', 'Phase', 'External-project-url', 'External-project-id', 'Privacy-policy-url'];

--- a/src/main/webapp/app/entities/source-type/source-type.service.ts
+++ b/src/main/webapp/app/entities/source-type/source-type.service.ts
@@ -33,9 +33,11 @@ export class SourceTypeService {
     }
 
     query(req?: any): Observable<Response> {
-        const options = this.createRequestOption(req);
-        return this.http.get(this.resourceUrl, options)
-                ;
+        let options = null;
+        if(req) {
+            options = this.createRequestOption(req);
+        }
+        return this.http.get(this.resourceUrl, options);
     }
 
     delete(producer: string, model: string, version: string): Observable<Response> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4565,10 +4565,6 @@ lodash@4.17.4, lodash@4.x.x, lodash@^4.0.0, lodash@^4.0.1, lodash@^4.11.1, lodas
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
-lodash@4.17.5:
-  version "4.17.5"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
-
 lodash@^3.10.1, lodash@^3.2.0, lodash@^3.3.1, lodash@^3.8.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"


### PR DESCRIPTION
GET request without pagination returns default pagination size set by spring. This causes issues when loading data in dialogs. E.g. loading source-types in project dialog.
Recommended fix was to provide a default pagination parameter. 

Related #229 