### PR TITLE
add default pagination to get all requests

### DIFF
--- a/src/main/java/org/radarcns/management/web/rest/ProjectResource.java
+++ b/src/main/java/org/radarcns/management/web/rest/ProjectResource.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -155,7 +156,8 @@ public class ProjectResource {
      */
     @GetMapping("/projects")
     @Timed
-    public ResponseEntity getAllProjects(@ApiParam Pageable pageable,
+    public ResponseEntity getAllProjects(
+            @PageableDefault(page = 0, size = Integer.MAX_VALUE) Pageable pageable,
             @RequestParam(name = "minimized", required = false, defaultValue = "false") Boolean
                     minimized) throws NotAuthorizedException {
         log.debug("REST request to get Projects");

--- a/src/main/java/org/radarcns/management/web/rest/RevisionResource.java
+++ b/src/main/java/org/radarcns/management/web/rest/RevisionResource.java
@@ -11,6 +11,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
@@ -39,7 +40,8 @@ public class RevisionResource {
     @GetMapping("/revisions")
     @Timed
     @Secured({AuthoritiesConstants.SYS_ADMIN})
-    public ResponseEntity<List<RevisionInfoDTO>> getRevisions(@ApiParam Pageable pageable) {
+    public ResponseEntity<List<RevisionInfoDTO>> getRevisions(
+            @PageableDefault(page = 0, size = Integer.MAX_VALUE) Pageable pageable) {
         log.debug("REST request to get page of revisions");
         Page<RevisionInfoDTO> page = revisionService.getRevisions(pageable);
         return new ResponseEntity<>(page.getContent(), PaginationUtil

--- a/src/main/java/org/radarcns/management/web/rest/RevisionResource.java
+++ b/src/main/java/org/radarcns/management/web/rest/RevisionResource.java
@@ -1,7 +1,6 @@
 package org.radarcns.management.web.rest;
 
 import com.codahale.metrics.annotation.Timed;
-import io.swagger.annotations.ApiParam;
 import org.radarcns.auth.authorization.AuthoritiesConstants;
 import org.radarcns.management.service.RevisionService;
 import org.radarcns.management.service.dto.RevisionInfoDTO;

--- a/src/main/java/org/radarcns/management/web/rest/SourceDataResource.java
+++ b/src/main/java/org/radarcns/management/web/rest/SourceDataResource.java
@@ -2,7 +2,6 @@ package org.radarcns.management.web.rest;
 
 import com.codahale.metrics.annotation.Timed;
 import io.github.jhipster.web.util.ResponseUtil;
-import io.swagger.annotations.ApiParam;
 import org.radarcns.auth.config.Constants;
 import org.radarcns.auth.exception.NotAuthorizedException;
 import org.radarcns.management.service.ResourceUriService;

--- a/src/main/java/org/radarcns/management/web/rest/SourceDataResource.java
+++ b/src/main/java/org/radarcns/management/web/rest/SourceDataResource.java
@@ -16,6 +16,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -120,7 +121,8 @@ public class SourceDataResource {
      */
     @GetMapping("/source-data")
     @Timed
-    public ResponseEntity<List<SourceDataDTO>> getAllSourceData(@ApiParam Pageable pageable)
+    public ResponseEntity<List<SourceDataDTO>> getAllSourceData(
+            @PageableDefault(page = 0, size = Integer.MAX_VALUE) Pageable pageable)
             throws NotAuthorizedException {
         log.debug("REST request to get all SourceData");
         checkPermission(getJWT(servletRequest), SOURCEDATA_READ);

--- a/src/main/java/org/radarcns/management/web/rest/SourceResource.java
+++ b/src/main/java/org/radarcns/management/web/rest/SourceResource.java
@@ -18,6 +18,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -165,7 +166,8 @@ public class SourceResource {
      */
     @GetMapping("/sources")
     @Timed
-    public ResponseEntity<List<SourceDTO>> getAllSources(@ApiParam Pageable pageable) {
+    public ResponseEntity<List<SourceDTO>> getAllSources(
+            @PageableDefault(page = 0, size = Integer.MAX_VALUE) Pageable pageable) {
         log.debug("REST request to get all Sources");
         Page<SourceDTO> page = sourceService.findAll(pageable);
         HttpHeaders headers = PaginationUtil

--- a/src/main/java/org/radarcns/management/web/rest/SourceResource.java
+++ b/src/main/java/org/radarcns/management/web/rest/SourceResource.java
@@ -2,7 +2,6 @@ package org.radarcns.management.web.rest;
 
 import com.codahale.metrics.annotation.Timed;
 import io.github.jhipster.web.util.ResponseUtil;
-import io.swagger.annotations.ApiParam;
 import org.radarcns.auth.config.Constants;
 import org.radarcns.auth.exception.NotAuthorizedException;
 import org.radarcns.management.domain.SourceType;

--- a/src/main/java/org/radarcns/management/web/rest/SubjectResource.java
+++ b/src/main/java/org/radarcns/management/web/rest/SubjectResource.java
@@ -66,6 +66,7 @@ import org.springframework.boot.actuate.audit.AuditEvent;
 import org.springframework.boot.actuate.audit.AuditEventRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -239,7 +240,8 @@ public class SubjectResource {
      */
     @GetMapping("/subjects")
     @Timed
-    public ResponseEntity<List<SubjectDTO>> getAllSubjects(@ApiParam Pageable pageable,
+    public ResponseEntity<List<SubjectDTO>> getAllSubjects(
+            @PageableDefault(page = 0, size = Integer.MAX_VALUE) Pageable pageable,
             @RequestParam(value = "projectName", required = false) String projectName,
             @RequestParam(value = "externalId", required = false) String externalId,
             @RequestParam(value = "withInactiveParticipants", required = false)

--- a/src/main/java/org/radarcns/management/web/rest/UserResource.java
+++ b/src/main/java/org/radarcns/management/web/rest/UserResource.java
@@ -2,7 +2,6 @@ package org.radarcns.management.web.rest;
 
 import com.codahale.metrics.annotation.Timed;
 import io.github.jhipster.web.util.ResponseUtil;
-import io.swagger.annotations.ApiParam;
 import org.radarcns.auth.config.Constants;
 import org.radarcns.auth.exception.NotAuthorizedException;
 import org.radarcns.management.config.ManagementPortalProperties;

--- a/src/main/java/org/radarcns/management/web/rest/UserResource.java
+++ b/src/main/java/org/radarcns/management/web/rest/UserResource.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -211,7 +212,8 @@ public class UserResource {
      */
     @GetMapping("/users")
     @Timed
-    public ResponseEntity<List<UserDTO>> getUsers(@ApiParam Pageable pageable,
+    public ResponseEntity<List<UserDTO>> getUsers(
+            @PageableDefault(page = 0, size = Integer.MAX_VALUE) Pageable pageable,
             UserFilter userFilter)
             throws NotAuthorizedException {
         checkPermission(getJWT(servletRequest), USER_READ);


### PR DESCRIPTION
GET ALL request returns the first page even when a pagination request was not issued. 
This can be fixed by adding default pagination parameter to the rest resources. 
Fixes #229 