### PR TITLE
add empty secret check box to allow empty secrets for public clients

### DIFF
--- a/src/main/java/org/radarcns/management/web/rest/OAuthClientsResource.java
+++ b/src/main/java/org/radarcns/management/web/rest/OAuthClientsResource.java
@@ -10,6 +10,7 @@ import static org.radarcns.auth.authorization.RadarAuthorization.checkPermission
 import static org.radarcns.management.security.SecurityUtils.getJWT;
 import static org.radarcns.management.service.OAuthClientService.checkProtected;
 import static org.radarcns.management.web.rest.errors.EntityName.OAUTH_CLIENT;
+import static org.radarcns.management.web.rest.errors.ErrorConstants.ERR_OAUTH_CLIENT_ALREADY_EXISTS;
 
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
@@ -31,6 +32,7 @@ import org.radarcns.management.service.dto.ClientPairInfoDTO;
 import org.radarcns.management.service.dto.SubjectDTO;
 import org.radarcns.management.service.mapper.ClientDetailsMapper;
 import org.radarcns.management.service.mapper.SubjectMapper;
+import org.radarcns.management.web.rest.errors.ConflictException;
 import org.radarcns.management.web.rest.util.HeaderUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -172,6 +174,10 @@ public class OAuthClientsResource {
     public ResponseEntity<ClientDetailsDTO> createOAuthClient(@Valid @RequestBody ClientDetailsDTO
             clientDetailsDto) throws URISyntaxException, NotAuthorizedException {
         checkPermission(getJWT(servletRequest), OAUTHCLIENTS_CREATE);
+        if (oAuthClientService.findOneByClientId(clientDetailsDto.getClientId()) != null) {
+            throw new ConflictException("A Client already exists with client-id " +
+                    clientDetailsDto.getClientId(), OAUTH_CLIENT, ERR_OAUTH_CLIENT_ALREADY_EXISTS);
+        }
         ClientDetails created = oAuthClientService.createClientDetail(clientDetailsDto);
         return ResponseEntity.created(ResourceUriService.getUri(clientDetailsDto))
                 .headers(HeaderUtil.createEntityCreationAlert(OAUTH_CLIENT, created.getClientId()))

--- a/src/main/java/org/radarcns/management/web/rest/OAuthClientsResource.java
+++ b/src/main/java/org/radarcns/management/web/rest/OAuthClientsResource.java
@@ -175,8 +175,9 @@ public class OAuthClientsResource {
             clientDetailsDto) throws URISyntaxException, NotAuthorizedException {
         checkPermission(getJWT(servletRequest), OAUTHCLIENTS_CREATE);
         if (oAuthClientService.findOneByClientId(clientDetailsDto.getClientId()) != null) {
-            throw new ConflictException("A Client already exists with client-id " +
-                    clientDetailsDto.getClientId(), OAUTH_CLIENT, ERR_OAUTH_CLIENT_ALREADY_EXISTS);
+            throw new ConflictException(
+                    "A Client already exists with client-id " + clientDetailsDto.getClientId(),
+                    OAUTH_CLIENT, ERR_OAUTH_CLIENT_ALREADY_EXISTS);
         }
         ClientDetails created = oAuthClientService.createClientDetail(clientDetailsDto);
         return ResponseEntity.created(ResourceUriService.getUri(clientDetailsDto))

--- a/src/main/java/org/radarcns/management/web/rest/OAuthClientsResource.java
+++ b/src/main/java/org/radarcns/management/web/rest/OAuthClientsResource.java
@@ -10,7 +10,6 @@ import static org.radarcns.auth.authorization.RadarAuthorization.checkPermission
 import static org.radarcns.management.security.SecurityUtils.getJWT;
 import static org.radarcns.management.service.OAuthClientService.checkProtected;
 import static org.radarcns.management.web.rest.errors.EntityName.OAUTH_CLIENT;
-import static org.radarcns.management.web.rest.errors.ErrorConstants.ERR_OAUTH_CLIENT_ALREADY_EXISTS;
 
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
@@ -32,7 +31,6 @@ import org.radarcns.management.service.dto.ClientPairInfoDTO;
 import org.radarcns.management.service.dto.SubjectDTO;
 import org.radarcns.management.service.mapper.ClientDetailsMapper;
 import org.radarcns.management.service.mapper.SubjectMapper;
-import org.radarcns.management.web.rest.errors.ConflictException;
 import org.radarcns.management.web.rest.util.HeaderUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -174,11 +172,6 @@ public class OAuthClientsResource {
     public ResponseEntity<ClientDetailsDTO> createOAuthClient(@Valid @RequestBody ClientDetailsDTO
             clientDetailsDto) throws URISyntaxException, NotAuthorizedException {
         checkPermission(getJWT(servletRequest), OAUTHCLIENTS_CREATE);
-        if (oAuthClientService.findOneByClientId(clientDetailsDto.getClientId()) != null) {
-            throw new ConflictException(
-                    "A Client already exists with client-id " + clientDetailsDto.getClientId(),
-                    OAUTH_CLIENT, ERR_OAUTH_CLIENT_ALREADY_EXISTS);
-        }
         ClientDetails created = oAuthClientService.createClientDetail(clientDetailsDto);
         return ResponseEntity.created(ResourceUriService.getUri(clientDetailsDto))
                 .headers(HeaderUtil.createEntityCreationAlert(OAUTH_CLIENT, created.getClientId()))

--- a/src/main/java/org/radarcns/management/web/rest/errors/ErrorConstants.java
+++ b/src/main/java/org/radarcns/management/web/rest/errors/ErrorConstants.java
@@ -11,6 +11,7 @@ public final class ErrorConstants {
     public static final String ERR_SOURCE_TYPE_EXISTS = "error.sourceTypeExists";
     public static final String ERR_CLIENT_ID_EXISTS = "error.clientIdExists";
     public static final String ERR_OAUTH_CLIENT_PROTECTED = "error.oAuthClientProtected";
+    public static final String ERR_OAUTH_CLIENT_ALREADY_EXISTS = "error.oAuthClientExists";
     public static final String ERR_OAUTH_CLIENT_ID_NOT_FOUND = "error.oAuthClientIdNotFound";
     public static final String ERR_SUBJECT_NOT_FOUND = "error.subjectNotFound";
     public static final String ERR_SOURCE_NAME_EXISTS = "error.sourceNameExists";

--- a/src/main/webapp/app/entities/oauth-client/oauth-client-dialog.component.html
+++ b/src/main/webapp/app/entities/oauth-client/oauth-client-dialog.component.html
@@ -27,8 +27,19 @@
         </div>
         <div class="form-group">
             <label class="form-control-label" for="secret" jhiTranslate="managementPortalApp.oauthClient.clientSecret">Client Secret</label>
+
+            <div class="form-group">
+                <label class="form-control-label" for="dynamicRegistration" jhiTranslate="managementPortalApp.oauthClient.additionalInformation">Additional Information</label>
+                <div class="form-check">
+                    <label class="form-check-label">
+                        <input type="checkbox" id="emptySecret" class="form-check-input" name="emptySecret" [checked]="emptySecret" (change)="emptySecret = !emptySecret" [disabled]="protectedClient" /> Empty secret for Public Client
+                    </label>
+                </div>
+                <small id="emptySecretHelp" class="form-text text-muted">Enable it to set empty client secret. Public clients do not need a secret.</small>
+            </div>
+            <div id="secretInputBox" [hidden]="emptySecret">
             <div class="input-group">
-                <input type="text" class="form-control" id="secret" name="clientSecret" [(ngModel)]="client.clientSecret" [disabled]="protectedClient" [required]="newClient" />
+                <input type="text" class="form-control" id="secret" name="clientSecret" [(ngModel)]="client.clientSecret" [disabled]="protectedClient" [required]="newClient && !emptySecret" />
                 <span class="input-group-btn"><button class="btn btn-secondary" type="button" (click)="generateRandomSecret()"><span class="fa fa-magic">&nbsp;</span>Randomize</button></span>
             </div>
             <div [hidden]="!newClient || (newClient && !(editForm.controls.clientSecret?.dirty && editForm.controls.clientSecret?.invalid))">
@@ -38,6 +49,7 @@
                 </small>
             </div>
             <small id="secretHelp" class="form-text text-muted" *ngIf="!newClient">If this field is left empty the secret will not be modified.</small>
+            </div>
         </div>
         <div class="form-group">
             <label class="form-control-label" for="scope" jhiTranslate="managementPortalApp.oauthClient.scope">Scope</label>

--- a/src/main/webapp/app/entities/oauth-client/oauth-client-dialog.component.ts
+++ b/src/main/webapp/app/entities/oauth-client/oauth-client-dialog.component.ts
@@ -23,6 +23,7 @@ export class OAuthClientDialogComponent implements OnInit {
     resourcesList: string;
     autoApproveScopeList: string;
     dynamicRegistration: boolean;
+    emptySecret: boolean;
     dynamicRegistrationKey: string;
     newClient: boolean;
     protectedClient: boolean;
@@ -83,6 +84,11 @@ export class OAuthClientDialogComponent implements OnInit {
         } else {
             delete this.client.additionalInformation[this.dynamicRegistrationKey];
         }
+
+        if (this.emptySecret) {
+            this.client.clientSecret = '';
+        }
+
         if (!this.newClient) {
             this.oauthClientSerivce.update(this.client)
             .subscribe((res: OAuthClient) =>

--- a/src/main/webapp/i18n/en/oauthClient.json
+++ b/src/main/webapp/i18n/en/oauthClient.json
@@ -22,13 +22,14 @@
             "refreshTokenValidity": "Refresh Token Validity",
             "authorities": "Authorities",
             "additionalInformation": "Additional Information",
-            "actions": "Actions",
-            "error": {
-                "validation": "Validation error, check the entered values in the fields.",
-                "oAuthClientProtected": "{{ param0 }} is a protected OAuth client can not be modified",
-                "oAuthClientIdNotFound": "The client id could not be found",
-                "subjectNotFound": "The subject login could not be found"
-            }
+            "actions": "Actions"
         }
+    },
+    "error": {
+        "validation": "Validation error, check the entered values in the fields.",
+        "oAuthClientProtected": "{{ param0 }} is a protected OAuth client can not be modified",
+        "oAuthClientIdNotFound": "The client id could not be found",
+        "subjectNotFound": "The subject login could not be found",
+        "oAuthClientExists": "A OAuth client already exists with the same client-id"
     }
 }

--- a/src/main/webapp/i18n/nl/oauthClient.json
+++ b/src/main/webapp/i18n/nl/oauthClient.json
@@ -22,13 +22,14 @@
             "refreshTokenValidity": "Refresh Token Validity",
             "authorities": "Authorities",
             "additionalInformation": "Additional Information",
-            "actions": "Actions",
-            "error": {
-                "validation": "Validatie fout, controleer de ingevoerde waarden.",
-                "oAuthClientProtected": "{{ param0 }} is een beschermde OAuth client en kan niet gewijzigd worden",
-                "oAuthClientIdNotFound": "De client id kon niet gevonden worden",
-                "subjectNotFound": "De deelnemer login kon niet gevonden worden"
-            }
+            "actions": "Actions"
         }
+    },
+    "error": {
+        "validation": "Validatie fout, controleer de ingevoerde waarden.",
+        "oAuthClientProtected": "{{ param0 }} is een beschermde OAuth client en kan niet gewijzigd worden",
+        "oAuthClientIdNotFound": "De client id kon niet gevonden worden",
+        "subjectNotFound": "De deelnemer login kon niet gevonden worden",
+        "oAuthClientExists": "Er bestaat al een OAuth-client met dezelfde client-ID"
     }
 }


### PR DESCRIPTION
Adds additional check-box to set empty secrets when necessary. This can be useful for public clients or to reset empty password for existing clients.

NOTE: Currently, we load some clients by default when we start MP service. During that load we override client values using the values provided in CSV. So if  you change the password from the UI for a client that is available on CSV, make sure you change the secret on the CSV file as well.

Fixes #348 