### PR TITLE
Fix subject-source assignment getting lost after a source is edited.

### DIFF
--- a/src/main/java/org/radarcns/management/domain/Subject.java
+++ b/src/main/java/org/radarcns/management/domain/Subject.java
@@ -65,7 +65,7 @@ public class Subject extends AbstractEntity implements Serializable {
     @Cascade(CascadeType.ALL)
     private User user;
 
-    @OneToMany(mappedBy = "subject")
+    @OneToMany(mappedBy = "subject", fetch = FetchType.EAGER)
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @Cascade(CascadeType.SAVE_UPDATE)
     private Set<Source> sources = new HashSet<>();

--- a/src/main/java/org/radarcns/management/service/dto/SourceDTO.java
+++ b/src/main/java/org/radarcns/management/service/dto/SourceDTO.java
@@ -29,6 +29,8 @@ public class SourceDTO implements Serializable {
     @NotNull
     private SourceTypeDTO sourceType;
 
+    private String subjectLogin;
+
     private MinimalProjectDetailsDTO project;
 
     private Map<String, String> attributes;
@@ -97,6 +99,14 @@ public class SourceDTO implements Serializable {
         this.expectedSourceName = expectedSourceName;
     }
 
+    public String getSubjectLogin() {
+        return subjectLogin;
+    }
+
+    public void setSubjectLogin(String subjectLogin) {
+        this.subjectLogin = subjectLogin;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -105,16 +115,23 @@ public class SourceDTO implements Serializable {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-
-        SourceDTO sourceDto = (SourceDTO) o;
-
-        return Objects.equals(sourceId, sourceDto.sourceId)
-                && Objects.equals(sourceName, sourceDto.sourceName);
+        SourceDTO source = (SourceDTO) o;
+        return Objects.equals(id, source.id)
+                && Objects.equals(sourceId, source.sourceId)
+                && Objects.equals(sourceName, source.sourceName)
+                && Objects.equals(expectedSourceName, source.expectedSourceName)
+                && Objects.equals(assigned, source.assigned)
+                && Objects.equals(sourceType, source.sourceType)
+                && Objects.equals(subjectLogin, source.subjectLogin)
+                && Objects.equals(project, source.project)
+                && Objects.equals(attributes, source.attributes);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(sourceId, sourceName);
+
+        return Objects.hash(id, sourceId, sourceName, expectedSourceName, assigned, sourceType,
+                subjectLogin, project, attributes);
     }
 
     @Override
@@ -126,6 +143,7 @@ public class SourceDTO implements Serializable {
                 + ", assigned=" + assigned
                 + ", sourceType=" + sourceType
                 + ", project=" + project
+                + ", subjectLogin=" + subjectLogin
                 + '}';
     }
 }

--- a/src/main/java/org/radarcns/management/service/mapper/SourceMapper.java
+++ b/src/main/java/org/radarcns/management/service/mapper/SourceMapper.java
@@ -17,6 +17,7 @@ import java.util.List;
 @DecoratedWith(SourceMapperDecorator.class)
 public interface SourceMapper {
 
+    @Mapping(source = "source.subject.user.login", target = "subjectLogin")
     SourceDTO sourceToSourceDTO(Source source);
 
     @Mapping(source = "sourceType.id", target = "sourceTypeId")
@@ -37,6 +38,4 @@ public interface SourceMapper {
 
     @Mapping(target = "subject", ignore = true)
     Source sourceDTOToSource(SourceDTO sourceDto);
-
-    List<Source> sourceDTOsToSources(List<SourceDTO> sourceDtos);
 }

--- a/src/main/java/org/radarcns/management/service/mapper/decorator/SourceMapperDecorator.java
+++ b/src/main/java/org/radarcns/management/service/mapper/decorator/SourceMapperDecorator.java
@@ -3,9 +3,12 @@ package org.radarcns.management.service.mapper.decorator;
 import java.util.Optional;
 import org.radarcns.management.domain.Source;
 import org.radarcns.management.repository.SourceRepository;
+import org.radarcns.management.repository.SubjectRepository;
 import org.radarcns.management.service.dto.MinimalSourceDetailsDTO;
+import org.radarcns.management.service.dto.SourceDTO;
 import org.radarcns.management.service.mapper.SourceMapper;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 
 /**
  * Created by nivethika on 13-6-17.
@@ -14,7 +17,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 public abstract class SourceMapperDecorator implements SourceMapper {
 
     @Autowired
+    @Qualifier("delegate")
+    private SourceMapper delegate;
+
+    @Autowired
     private SourceRepository sourceRepository;
+
+    @Autowired
+    private SubjectRepository subjectRepository;
 
     @Override
     public Source descriptiveDTOToSource(MinimalSourceDetailsDTO minimalSource) {
@@ -26,6 +36,21 @@ public abstract class SourceMapperDecorator implements SourceMapper {
         }
         Source source = sourceOpt.get();
         source.setAssigned(minimalSource.isAssigned());
+        return source;
+    }
+
+    @Override
+    public Source sourceDTOToSource(SourceDTO sourceDto) {
+        Source source = delegate.sourceDTOToSource(sourceDto);
+        if (sourceDto.getId() != null) {
+            Source existingSource = sourceRepository.findOne(sourceDto.getId());
+            if (sourceDto.getSubjectLogin() == null) {
+                source.setSubject(existingSource.getSubject());
+            } else {
+                source.setSubject(subjectRepository.findOneWithEagerBySubjectLogin(sourceDto
+                        .getSubjectLogin()).get());
+            }
+        }
         return source;
     }
 }

--- a/src/test/java/org/radarcns/management/web/rest/SourceResourceIntTest.java
+++ b/src/test/java/org/radarcns/management/web/rest/SourceResourceIntTest.java
@@ -108,7 +108,6 @@ public class SourceResourceIntTest {
         ReflectionTestUtils.setField(sourceResource, "servletRequest", servletRequest);
         ReflectionTestUtils.setField(sourceResource, "sourceService", sourceService);
         ReflectionTestUtils.setField(sourceResource, "sourceRepository", sourceRepository);
-        ReflectionTestUtils.setField(sourceResource, "projectRepository", projectRepository);
 
         JwtAuthenticationFilter filter = OAuthHelper.createAuthenticationFilter();
         filter.init(new MockFilterConfig());


### PR DESCRIPTION
The old `ManyToMany` mapping subject-source relationship was maintained in a separate table with two foreign Keys. After moving to `OneToMany` source -> subject relationship is maintained by a foreign-key in source. However, the update method does not consider this change. 
During update of a source, assigned subject gets lost due to the existing implementation of the mapper where subject is ignored. 
Fix is made by explicitly setting the subject from existing source or by subjectLogin. 

Note: If an already assigned source was edited for some reason, the corresponding subject to whom the source was assigned is lost. This would have created inconsistant data which says a source is assigned, but cannot find the assigned subject.  
Fixes #345.