### PR TITLE
Auth0 validation with shading

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ memory database and ManagementPortal.
 
 
 
-The docker image can be pulled by running `docker pull radarbase/management-portal:0.3.8`.
+The docker image can be pulled by running `docker pull radarbase/management-portal:0.5.4`.
 
 ## Configuration
 
@@ -102,13 +102,15 @@ for other options on overriding the default configuration.
 | `MANAGEMENTPORTAL_OAUTH_CLIENTS_FILE`                      | `/mp-includes/config/oauth_client_details.csv`      | Location of the OAuth clients file                                                                     |
 | `MANAGEMENTPORTAL_OAUTH_KEY_STORE_PASSWORD`                | `radarbase`                                         | Password for the JWT keystore                                                                          |
 | `MANAGEMENTPORTAL_OAUTH_SIGNING_KEY_ALIAS`                 | `radarbase-managementportal-ec`                     | Alias in the keystore of the keypair to use for signing                                                |
-| `MANAGEMENTPORTAL_CATALOGUE_SERVER_ENABLE_AUTO_IMPORT`     | `false`                                             | Wether to enable or disable auto import of sources from the catalogue server                           |
+| `MANAGEMENTPORTAL_OAUTH_ENABLE_PUBLIC_KEY_VERIFIERS`       | `false`                                             | Whether to use additional verifiers using public-keys and deprecated verifier implementation. If you set this to `true`, also set `RADAR_IS_CONFIG_LOCATION` and provide yaml file with public keys. Read more at radar-auth documentation.         |
+| `MANAGEMENTPORTAL_CATALOGUE_SERVER_ENABLE_AUTO_IMPORT`     | `false`                                             | Whether to enable or disable auto import of sources from the catalogue server                          |
 | `MANAGEMENTPORTAL_CATALOGUE_SERVER_SERVER_URL`             | None                                                | URL to the catalogue server                                                                            |
 | `MANAGEMENTPORTAL_COMMON_BASE_URL`                         | None                                                | Resolvable baseUrl of the hosted platform                                                              |
 | `MANAGEMENTPORTAL_COMMON_MANAGEMENT_PORTAL_BASE_URL`       | None                                                | Resolvable baseUrl of this managementportal  instance                                                  |
 | `MANAGEMENTPORTAL_COMMON_PRIVACY_POLICY_URL`               | None                                                | Resolvable URL to the common privacy policy url                                                        |
 | `MANAGEMENTPORTAL_COMMON_ADMIN_PASSWORD`                   | None                                                | Admin password                                                                                         |
-| `MANAGEMENTPORTAL_COMMON_ACTIVATION_KEY_TIMEOUT_IN_SECONDS`                   | 86400                                                | Account activation/reset timeout in seconds                                                                                      |
+| `MANAGEMENTPORTAL_COMMON_ACTIVATION_KEY_TIMEOUT_IN_SECONDS`                   | 86400                            | Account activation/reset timeout in seconds                                                                                      |
+| `RADAR_IS_CONFIG_LOCATION`                                 | `radar-is.yml` from class path                      | Location of additional public-key configuration file.                                                                                   |
 | `JHIPSTER_SLEEP`                                           | `10`                                                | Time in seconds that the application should wait at bootup. Used to allow the database to become ready |
 | `JAVA_OPTS`                                                | `-Xmx512m`                                          | Options to pass on the JVM                                                                             |
 

--- a/radar-auth/README.md
+++ b/radar-auth/README.md
@@ -37,6 +37,8 @@ or
 
 ```yaml
 resourceName: res_ManagementPortal
+publicKeyEndpoints:
+ - http://localhost:8080/oauth/token_key
 publicKeys:
   - |-
     -----BEGIN PUBLIC KEY-----
@@ -47,6 +49,12 @@ publicKeys:
     MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEvmBia5inhASHAVrFBB5JAh0ne/aKb6z/sCIuWzKp/azFcD/OPJ2H6RPLn3t7XA4oAa2FR3GB4ZhU7SCh20FUhA==
     -----END EC PUBLIC KEY-----
 ```
+
+
+We have deprecated the use of public key configurations in radar-is.yml for token validation from radar-auth:0.5.5.
+We recommend you to fetch public keys from Management Portal, instead of locally configuring public-keys. 
+We have upgraded to java-jwt:0.3.7 from radar-auth:0.5.4, which have refactored support for ECDSA algorithms.
+If you have used management-portal:0.5.3 or earlier versions, you can use deprecated public-key configurations to keep validating old signatures. 
 
 Usage
 -----

--- a/radar-auth/build.gradle
+++ b/radar-auth/build.gradle
@@ -16,7 +16,7 @@ repositories {
 }
 
 dependencies {
-    shadow project(path: ':radar-auth:deprecated-auth0', configuration: 'shadow')
+    implementation project(path: ':radar-auth:deprecated-auth0', configuration: 'shadow')
     api group: 'com.auth0', name: 'java-jwt', version: oauthJwtVersion
     implementation group: 'com.squareup.okhttp3', name: 'okhttp', version: okhttpVersion
 
@@ -38,7 +38,7 @@ shadowJar {
 
 publishing {
     publications {
-        shadow(MavenPublication) {
+        mavenJar(MavenPublication) {
             publication -> project.shadow.component(publication)
         }
     }

--- a/radar-auth/build.gradle
+++ b/radar-auth/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'com.github.johnrengelman.shadow' version '5.0.0'
+}
+
 ext.jacksonVersion = '2.9.8'
 ext.okhttpVersion = '3.14.0'
 ext.oauthJwtVersion = '3.7.0'
@@ -10,6 +14,7 @@ repositories {
 }
 
 dependencies {
+    shadow project(path: ':radar-auth:deprecated-auth0', configuration: 'shadow')
     api group: 'com.auth0', name: 'java-jwt', version: oauthJwtVersion
     implementation group: 'com.squareup.okhttp3', name: 'okhttp', version: okhttpVersion
 
@@ -24,6 +29,11 @@ dependencies {
 
     testRuntimeOnly group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
 }
+
+shadowJar {
+    configurations = [project.configurations.shadow]
+}
+
 
 apply from: '../gradle/style.gradle'
 apply from: '../gradle/publishing.gradle'

--- a/radar-auth/build.gradle
+++ b/radar-auth/build.gradle
@@ -2,6 +2,8 @@ plugins {
     id 'com.github.johnrengelman.shadow' version '5.0.0'
 }
 
+apply plugin: 'maven-publish'
+
 ext.jacksonVersion = '2.9.8'
 ext.okhttpVersion = '3.14.0'
 ext.oauthJwtVersion = '3.7.0'
@@ -34,6 +36,13 @@ shadowJar {
     configurations = [project.configurations.shadow]
 }
 
+publishing {
+    publications {
+        shadow(MavenPublication) {
+            publication -> project.shadow.component(publication)
+        }
+    }
+}
 
 apply from: '../gradle/style.gradle'
 apply from: '../gradle/publishing.gradle'

--- a/radar-auth/deprecated-auth0/build.gradle
+++ b/radar-auth/deprecated-auth0/build.gradle
@@ -1,0 +1,18 @@
+plugins {
+    id 'com.github.johnrengelman.shadow' 
+}
+
+
+repositories {
+    jcenter()
+    mavenLocal()
+}
+
+dependencies {
+    shadow group: 'com.auth0', name: 'java-jwt', version: '3.2.0'
+}
+
+shadowJar {
+    configurations = [project.configurations.shadow]
+    relocate 'com.auth0.jwt', 'shadow.auth0.jwt'
+}

--- a/radar-auth/deprecated-auth0/build.gradle
+++ b/radar-auth/deprecated-auth0/build.gradle
@@ -2,7 +2,6 @@ plugins {
     id 'com.github.johnrengelman.shadow' 
 }
 
-
 repositories {
     jcenter()
     mavenLocal()

--- a/radar-auth/settings.gradle
+++ b/radar-auth/settings.gradle
@@ -1,1 +1,2 @@
 rootProject.name = 'radar-auth'
+include 'deprecated-auth0'

--- a/radar-auth/src/main/java/org/radarcns/auth/authentication/AlgorithmLoader.java
+++ b/radar-auth/src/main/java/org/radarcns/auth/authentication/AlgorithmLoader.java
@@ -18,21 +18,21 @@ import org.radarcns.auth.token.validation.deprecated.DeprecatedEcTokenValidation
 public class AlgorithmLoader {
 
     private final List<TokenValidationAlgorithm> supportedAlgorithmsForWebKeySets;
-    private final List<TokenValidationAlgorithm> supportedAlgorithmsForPublicKeys;
+    private final List<TokenValidationAlgorithm> supportedAlgorithmsForPublicKeysInConfig;
 
     /**
      * Creates an instance of {@link AlgorithmLoader} with lists of
      * {@link TokenValidationAlgorithm} provided.
-     * @param algorithmsForWebKeys default support. Algorithms to be supported for
+     * @param supportedAlgorithmsForWebKeySets default support. Algorithms to be supported for
      *                             public keys shared from public key endpoints as
      *                             {@link JavaWebKeySet}.
-     * @param algorithmsForLocalPublicKeys deprecated support. Algorithms to be supported for
-     *                                     public keys configured in config file.
+     * @param supportedAlgorithmsForPublicKeysInConfig deprecated support. Algorithms to be
+     *                                      supported for public keys configured in config file.
      */
-    public AlgorithmLoader(List<TokenValidationAlgorithm> algorithmsForWebKeys,
-            List<TokenValidationAlgorithm> algorithmsForLocalPublicKeys) {
-        this.supportedAlgorithmsForWebKeySets = algorithmsForWebKeys;
-        this.supportedAlgorithmsForPublicKeys = algorithmsForLocalPublicKeys;
+    public AlgorithmLoader(List<TokenValidationAlgorithm> supportedAlgorithmsForWebKeySets,
+            List<TokenValidationAlgorithm> supportedAlgorithmsForPublicKeysInConfig) {
+        this.supportedAlgorithmsForWebKeySets = supportedAlgorithmsForWebKeySets;
+        this.supportedAlgorithmsForPublicKeysInConfig = supportedAlgorithmsForPublicKeysInConfig;
     }
 
     /**
@@ -72,7 +72,7 @@ public class AlgorithmLoader {
     public Algorithm loadDeprecatedAlgorithmFromPublicKey(String publicKey) {
         // We deny to trust the public key if the reported algorithm is unknown to us
         // https://auth0.com/blog/critical-vulnerabilities-in-json-web-token-libraries/
-        return loadAlgorithmFromPublicKey(supportedAlgorithmsForPublicKeys, publicKey);
+        return loadAlgorithmFromPublicKey(supportedAlgorithmsForPublicKeysInConfig, publicKey);
     }
 
     /**

--- a/radar-auth/src/main/java/org/radarcns/auth/authentication/AlgorithmLoader.java
+++ b/radar-auth/src/main/java/org/radarcns/auth/authentication/AlgorithmLoader.java
@@ -1,0 +1,64 @@
+package org.radarcns.auth.authentication;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.JWTVerifier;
+import com.auth0.jwt.algorithms.Algorithm;
+import org.radarcns.auth.exception.TokenValidationException;
+import org.radarcns.auth.security.jwk.JavaWebKey;
+import org.radarcns.auth.security.jwk.JavaWebKeySet;
+import org.radarcns.auth.token.validation.ECTokenValidationAlgorithm;
+import org.radarcns.auth.token.validation.RSATokenValidationAlgorithm;
+import org.radarcns.auth.token.validation.TokenValidationAlgorithm;
+import org.radarcns.auth.token.validation.deprecated.DeprecatedEcTokenValidationAlgorithm;
+
+public class AlgorithmLoader {
+
+    private static final List<TokenValidationAlgorithm> algorithmList = Arrays.asList(
+            new ECTokenValidationAlgorithm(),
+            new RSATokenValidationAlgorithm());
+    private static final List<TokenValidationAlgorithm> supportedAlgorithmsForPublicKeys = Arrays.asList(
+            new DeprecatedEcTokenValidationAlgorithm(),
+            new RSATokenValidationAlgorithm());
+
+    private static Algorithm algorithmFromPublicKey(String publicKey) {
+        // We deny to trust the public key if the reported algorithm is unknown to us
+        // https://auth0.com/blog/critical-vulnerabilities-in-json-web-token-libraries/
+        return loadAlgorithmFromPublicKey(algorithmList, publicKey);
+    }
+
+    private static Algorithm loadAlgorithmFromPublicKey(
+            List<TokenValidationAlgorithm> supportedAlgorithms, String publicKey) {
+        return supportedAlgorithms
+                .stream()
+                .filter(algorithm -> publicKey.startsWith(algorithm.getKeyHeader()))
+                .findFirst()
+                .orElseThrow(() ->
+                        new TokenValidationException("Unsupported public key: " + publicKey))
+                .getAlgorithm(publicKey);
+    }
+
+    public static Algorithm loadDeprecatedAlgorithmFromPublicKey(String publicKey) {
+        // We deny to trust the public key if the reported algorithm is unknown to us
+        // https://auth0.com/blog/critical-vulnerabilities-in-json-web-token-libraries/
+        return loadAlgorithmFromPublicKey(supportedAlgorithmsForPublicKeys, publicKey);
+    }
+
+    public static List<Algorithm> loadAlgorithmsFromJavaWebKeys(JavaWebKeySet publicKeyInfo) {
+        return publicKeyInfo
+                .getKeys()
+                .stream()
+                .map(JavaWebKey::getValue)
+                .map(AlgorithmLoader::algorithmFromPublicKey)
+                .collect(Collectors.toList());
+    }
+
+    public static JWTVerifier buildVerifier(Algorithm algorithm, String audience) {
+        return JWT.require(algorithm)
+                .withAudience(audience)
+                .build();
+    }
+}

--- a/radar-auth/src/main/java/org/radarcns/auth/authentication/AlgorithmLoader.java
+++ b/radar-auth/src/main/java/org/radarcns/auth/authentication/AlgorithmLoader.java
@@ -20,7 +20,8 @@ public class AlgorithmLoader {
     private static final List<TokenValidationAlgorithm> algorithmList = Arrays.asList(
             new ECTokenValidationAlgorithm(),
             new RSATokenValidationAlgorithm());
-    private static final List<TokenValidationAlgorithm> supportedAlgorithmsForPublicKeys = Arrays.asList(
+    private static final List<TokenValidationAlgorithm> supportedAlgorithmsForPublicKeys =
+            Arrays.asList(
             new DeprecatedEcTokenValidationAlgorithm(),
             new RSATokenValidationAlgorithm());
 
@@ -41,12 +42,22 @@ public class AlgorithmLoader {
                 .getAlgorithm(publicKey);
     }
 
+    /**
+     * Loads algorithms using deprecated method.
+     * @param publicKey publicKeys to load algorithms.
+     * @return instance of {@link Algorithm}.
+     */
     public static Algorithm loadDeprecatedAlgorithmFromPublicKey(String publicKey) {
         // We deny to trust the public key if the reported algorithm is unknown to us
         // https://auth0.com/blog/critical-vulnerabilities-in-json-web-token-libraries/
         return loadAlgorithmFromPublicKey(supportedAlgorithmsForPublicKeys, publicKey);
     }
 
+    /**
+     * Loads Algorithms from {@link JavaWebKeySet}.
+     * @param publicKeyInfo java web key set to load algorithm.
+     * @return List of {@link Algorithm}.
+     */
     public static List<Algorithm> loadAlgorithmsFromJavaWebKeys(JavaWebKeySet publicKeyInfo) {
         return publicKeyInfo
                 .getKeys()
@@ -56,6 +67,12 @@ public class AlgorithmLoader {
                 .collect(Collectors.toList());
     }
 
+    /**
+     * Creates in {@link JWTVerifier} using Algorithms and audience.
+     * @param algorithm instance of {@link Algorithm} to create verifier from.
+     * @param audience to which audience.
+     * @return instance of {@link JWTVerifier}.
+     */
     public static JWTVerifier buildVerifier(Algorithm algorithm, String audience) {
         return JWT.require(algorithm)
                 .withAudience(audience)

--- a/radar-auth/src/main/java/org/radarcns/auth/authentication/TokenValidator.java
+++ b/radar-auth/src/main/java/org/radarcns/auth/authentication/TokenValidator.java
@@ -53,8 +53,8 @@ public class TokenValidator {
             new ECTokenValidationAlgorithm(),
             new RSATokenValidationAlgorithm());
     private final List<TokenValidationAlgorithm> supportedAlgorithmsForPublicKeys = Arrays.asList(
-            new ECTokenValidationAlgorithm(),
-            new DeprecatedEcTokenValidationAlgorithm());
+            new DeprecatedEcTokenValidationAlgorithm(),
+            new RSATokenValidationAlgorithm());
 
     // If a client presents a token with an invalid signature, it might be the keypair was changed.
     // In that case we need to fetch it again, but we don't want a malicious client to be able to

--- a/radar-auth/src/main/java/org/radarcns/auth/authentication/TokenValidator.java
+++ b/radar-auth/src/main/java/org/radarcns/auth/authentication/TokenValidator.java
@@ -61,7 +61,7 @@ public class TokenValidator {
     // make us DOS our own identity server. Fetching it at maximum once per minute mitigates this.
     private static final Duration FETCH_TIMEOUT_DEFAULT = Duration.ofMinutes(1);
     private final Duration fetchTimeout;
-    private Instant lastFetch = Instant.MIN;
+    private Instant lastFetch;
 
     private static final long DEFAULT_TIMEOUT = 30;
     private final OkHttpClient client = new OkHttpClient.Builder()
@@ -185,7 +185,7 @@ public class TokenValidator {
     private List<JWTVerifier> loadVerifiers() throws TokenValidationException {
         synchronized (this) {
             // whether successful or not, do not request the key more than once per minute
-            if (Instant.now().isBefore(lastFetch.plus(fetchTimeout))) {
+            if (lastFetch != null && Instant.now().isBefore(lastFetch.plus(fetchTimeout))) {
                 // it hasn't been long enough ago to fetch the key again, we deny access
                 LOGGER.warn("Fetched public key less than {} ago, denied access.", fetchTimeout);
                 throw new TokenValidationException("Not fetching public key more than once every "

--- a/radar-auth/src/main/java/org/radarcns/auth/authentication/TokenValidator.java
+++ b/radar-auth/src/main/java/org/radarcns/auth/authentication/TokenValidator.java
@@ -25,6 +25,7 @@ import org.radarcns.auth.token.RadarToken;
 import org.radarcns.auth.token.validation.ECTokenValidationAlgorithm;
 import org.radarcns.auth.token.validation.RSATokenValidationAlgorithm;
 import org.radarcns.auth.token.validation.TokenValidationAlgorithm;
+import org.radarcns.auth.token.validation.deprecated.DeprecatedEcTokenValidationAlgorithm;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,7 +51,9 @@ public class TokenValidator {
     private final TokenValidatorConfig config;
     private List<JWTVerifier> verifiers = new LinkedList<>();
     private final List<TokenValidationAlgorithm> algorithmList = Arrays.asList(
-            new ECTokenValidationAlgorithm(), new RSATokenValidationAlgorithm());
+            new ECTokenValidationAlgorithm(),
+            new RSATokenValidationAlgorithm(),
+            new DeprecatedEcTokenValidationAlgorithm());
 
     // If a client presents a token with an invalid signature, it might be the keypair was changed.
     // In that case we need to fetch it again, but we don't want a malicious client to be able to

--- a/radar-auth/src/main/java/org/radarcns/auth/authentication/TokenValidator.java
+++ b/radar-auth/src/main/java/org/radarcns/auth/authentication/TokenValidator.java
@@ -125,7 +125,6 @@ public class TokenValidator {
      * @throws TokenValidationException If the token can not be validated.
      */
     public RadarToken validateAccessToken(String token) throws TokenValidationException {
-        shadow.auth0.jwt.JWTVerifier verifier2;
         for (JWTVerifier verifier : getVerifiers()) {
             try {
                 DecodedJWT jwt = verifier.verify(token);

--- a/radar-auth/src/main/java/org/radarcns/auth/authentication/TokenValidator.java
+++ b/radar-auth/src/main/java/org/radarcns/auth/authentication/TokenValidator.java
@@ -60,6 +60,8 @@ public class TokenValidator {
 
     private final ObjectMapper mapper = new ObjectMapper();
 
+    private final AlgorithmLoader algorithmLoader = new AlgorithmLoader();
+
     /**
      * Default constructor. Will load the identity server configuration from a file called
      * radar-is.yml that should be on the classpath, or its location defined in the
@@ -200,7 +202,7 @@ public class TokenValidator {
                 .flatMap(List::stream);
 
         Stream<Algorithm> stringKeys = streamEmptyIfNull(config.getPublicKeys())
-                .map(AlgorithmLoader::loadDeprecatedAlgorithmFromPublicKey);
+                .map(algorithmLoader::loadDeprecatedAlgorithmFromPublicKey);
 
         // Create a verifier for each signature verification algorithm we created
         return Stream.concat(endpointKeys, stringKeys)
@@ -223,7 +225,7 @@ public class TokenValidator {
                 response.close();
                 LOGGER.debug("Processing {} public keys from public-key endpoint {}", publicKeyInfo
                         .getKeys().size(), serverUri.toURL());
-                return AlgorithmLoader.loadAlgorithmsFromJavaWebKeys(publicKeyInfo);
+                return algorithmLoader.loadAlgorithmsFromJavaWebKeys(publicKeyInfo);
             } else {
                 throw new TokenValidationException("Invalid token signature. Could not load "
                         + "newer public keys");

--- a/radar-auth/src/main/java/org/radarcns/auth/authentication/TokenValidator.java
+++ b/radar-auth/src/main/java/org/radarcns/auth/authentication/TokenValidator.java
@@ -225,7 +225,7 @@ public class TokenValidator {
                         .getKeys().size(), serverUri.toURL());
                 return AlgorithmLoader.loadAlgorithmsFromJavaWebKeys(publicKeyInfo);
             } else {
-                throw new TokenValidationException("Invalid token signature. Could load load "
+                throw new TokenValidationException("Invalid token signature. Could not load "
                         + "newer public keys");
             }
 

--- a/radar-auth/src/main/java/org/radarcns/auth/authentication/TokenValidator.java
+++ b/radar-auth/src/main/java/org/radarcns/auth/authentication/TokenValidator.java
@@ -125,6 +125,7 @@ public class TokenValidator {
      * @throws TokenValidationException If the token can not be validated.
      */
     public RadarToken validateAccessToken(String token) throws TokenValidationException {
+        shadow.auth0.jwt.JWTVerifier verifier2;
         for (JWTVerifier verifier : getVerifiers()) {
             try {
                 DecodedJWT jwt = verifier.verify(token);

--- a/radar-auth/src/main/java/org/radarcns/auth/authentication/TokenValidator.java
+++ b/radar-auth/src/main/java/org/radarcns/auth/authentication/TokenValidator.java
@@ -271,8 +271,8 @@ public class TokenValidator {
                 .stream()
                 .filter(algorithm -> publicKey.startsWith(algorithm.getKeyHeader()))
                 .findFirst()
-                .orElseThrow(
-                        () -> new TokenValidationException("Unsupported public key: " + publicKey))
+                .orElseThrow(() ->
+                        new TokenValidationException("Unsupported public key: " + publicKey))
                 .getAlgorithm(publicKey);
     }
 

--- a/radar-auth/src/main/java/org/radarcns/auth/config/TokenValidatorConfig.java
+++ b/radar-auth/src/main/java/org/radarcns/auth/config/TokenValidatorConfig.java
@@ -20,8 +20,10 @@ public interface TokenValidatorConfig {
 
     /**
      * Get the public keys set in the config file. They should be in PEM format.
-     * @return The public keys, or <code>null</code> if not defined
+     * @return The public keys, or <code>null</code> if not defined.
+     * @deprecated Use the {@link #getPublicKeyEndpoints()} instead to get public-keys.
      */
+    @Deprecated
     List<String> getPublicKeys();
 
 }

--- a/radar-auth/src/main/java/org/radarcns/auth/token/validation/deprecated/DeprecatedEcTokenValidationAlgorithm.java
+++ b/radar-auth/src/main/java/org/radarcns/auth/token/validation/deprecated/DeprecatedEcTokenValidationAlgorithm.java
@@ -1,0 +1,217 @@
+package org.radarcns.auth.token.validation.deprecated;
+
+import java.security.interfaces.ECPublicKey;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.SignatureGenerationException;
+import com.auth0.jwt.exceptions.SignatureVerificationException;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import org.radarcns.auth.token.validation.AbstractTokenValidationAlgorithm;
+import shadow.auth0.jwt.exceptions.JWTDecodeException;
+import shadow.auth0.jwt.interfaces.Claim;
+
+/**
+ * This is a deprecated algorithm to validate old tokens.
+ * Added to maintain compatibility with java-jwt:3.2.0 validators.
+ *
+ */
+@Deprecated
+public class DeprecatedEcTokenValidationAlgorithm extends AbstractTokenValidationAlgorithm {
+
+    @Override
+    public String getJwtAlgorithm() {
+        return "SHA256withECDSA";
+    }
+
+    @Override
+    public String getKeyHeader() {
+        return "-----BEGIN EC PUBLIC KEY-----";
+    }
+
+    @Override
+    public Algorithm getAlgorithm(String publicKey) {
+
+        shadow.auth0.jwt.algorithms.Algorithm deprecatedEcVerifier =
+                shadow.auth0.jwt.algorithms.Algorithm.ECDSA256((ECPublicKey) parseKey(publicKey),
+                null);
+        return new Algorithm(deprecatedEcVerifier.getName(), getJwtAlgorithm()) {
+            @Override
+            public void verify(DecodedJWT jwt) throws SignatureVerificationException {
+                deprecatedEcVerifier.verify(wrap(jwt));
+            }
+
+            @Override
+            public byte[] sign(byte[] contentBytes) throws SignatureGenerationException {
+                return deprecatedEcVerifier.sign(contentBytes);
+            }
+        };
+    }
+
+    private shadow.auth0.jwt.interfaces.DecodedJWT wrap(DecodedJWT jwt) {
+        return new shadow.auth0.jwt.interfaces.DecodedJWT() {
+            @Override
+            public String getToken() {
+                return jwt.getToken();
+            }
+
+            @Override
+            public String getHeader() {
+                return jwt.getHeader();
+            }
+
+            @Override
+            public String getPayload() {
+                return jwt.getPayload();
+            }
+
+            @Override
+            public String getSignature() {
+                return jwt.getSignature();
+            }
+
+            @Override
+            public String getAlgorithm() {
+                return jwt.getAlgorithm();
+            }
+
+            @Override
+            public String getType() {
+                return jwt.getType();
+            }
+
+            @Override
+            public String getContentType() {
+                return jwt.getContentType();
+            }
+
+            @Override
+            public String getKeyId() {
+                return jwt.getKeyId();
+            }
+
+            @Override
+            public Claim getHeaderClaim(String s) {
+                com.auth0.jwt.interfaces.Claim claim = jwt.getHeaderClaim(s);
+                return wrap(claim);
+            }
+
+            @Override
+            public String getIssuer() {
+                return jwt.getIssuer();
+            }
+
+            @Override
+            public String getSubject() {
+                return jwt.getSubject();
+            }
+
+            @Override
+            public List<String> getAudience() {
+                return jwt.getAudience();
+            }
+
+            @Override
+            public Date getExpiresAt() {
+                return jwt.getExpiresAt();
+            }
+
+            @Override
+            public Date getNotBefore() {
+                return jwt.getNotBefore();
+            }
+
+            @Override
+            public Date getIssuedAt() {
+                return jwt.getIssuedAt();
+            }
+
+            @Override
+            public String getId() {
+                return jwt.getId();
+            }
+
+            @Override
+            public Claim getClaim(String s) {
+                com.auth0.jwt.interfaces.Claim claim = jwt.getHeaderClaim(s);
+                return wrap(claim);
+            }
+
+            @Override
+            public Map<String, Claim> getClaims() {
+                Map<String, com.auth0.jwt.interfaces.Claim> claims = jwt.getClaims();
+                return claims.entrySet()
+                        .stream()
+                        .collect(Collectors.toMap(Map.Entry::getKey,
+                                e -> wrap(e.getValue())));
+            }
+        };
+    }
+
+    private Claim wrap(com.auth0.jwt.interfaces.Claim claim) {
+        return new Claim() {
+            @Override
+            public boolean isNull() {
+                return claim.isNull();
+            }
+
+            @Override
+            public Boolean asBoolean() {
+                return claim.asBoolean();
+            }
+
+            @Override
+            public Integer asInt() {
+                return claim.asInt();
+            }
+
+            @Override
+            public Long asLong() {
+                return claim.asLong();
+            }
+
+            @Override
+            public Double asDouble() {
+                return claim.asDouble();
+            }
+
+            @Override
+            public String asString() {
+                return claim.asString();
+            }
+
+            @Override
+            public Date asDate() {
+                return claim.asDate();
+            }
+
+            @Override
+            public <T> T[] asArray(Class<T> aClass) throws JWTDecodeException {
+                return claim.asArray(aClass);
+            }
+
+            @Override
+            public <T> List<T> asList(Class<T> aClass) throws JWTDecodeException {
+                return claim.asList(aClass);
+            }
+
+            @Override
+            public Map<String, Object> asMap() throws JWTDecodeException {
+                return claim.asMap();
+            }
+
+            @Override
+            public <T> T as(Class<T> aClass) throws JWTDecodeException {
+                return claim.as(aClass);
+            }
+        };
+    }
+
+    @Override
+    protected String getKeyFactoryType() {
+        return "EC";
+    }
+}

--- a/radar-auth/src/main/java/org/radarcns/auth/token/validation/deprecated/DeprecatedEcTokenValidationAlgorithm.java
+++ b/radar-auth/src/main/java/org/radarcns/auth/token/validation/deprecated/DeprecatedEcTokenValidationAlgorithm.java
@@ -145,8 +145,7 @@ public class DeprecatedEcTokenValidationAlgorithm extends AbstractTokenValidatio
                 Map<String, com.auth0.jwt.interfaces.Claim> claims = jwt.getClaims();
                 return claims.entrySet()
                         .stream()
-                        .collect(Collectors.toMap(Map.Entry::getKey,
-                                e -> wrap(e.getValue())));
+                        .collect(Collectors.toMap(Map.Entry::getKey, e -> wrap(e.getValue())));
             }
         };
     }

--- a/radar-auth/src/test/resources/radar-is.yml
+++ b/radar-auth/src/test/resources/radar-is.yml
@@ -1,7 +1,6 @@
 resourceName: unit_test
 publicKeyEndpoints:
   - http://localhost:8089/oauth/token_key
-  - http://localhost:8089/oauth/token_key # in our tests we only have one wiremock port open, so we have two times the same uri
 publicKeys:
   - |-
     -----BEGIN PUBLIC KEY-----

--- a/radar-auth/src/test/resources/radar-is.yml
+++ b/radar-auth/src/test/resources/radar-is.yml
@@ -1,6 +1,7 @@
 resourceName: unit_test
 publicKeyEndpoints:
   - http://localhost:8089/oauth/token_key
+  - http://localhost:8089/oauth/token_key # in our tests we only have one wiremock port open, so we have two times the same uri
 publicKeys:
   - |-
     -----BEGIN PUBLIC KEY-----

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,4 @@
 rootProject.name = 'management-portal'
 include 'oauth-client-util'
 include 'radar-auth'
+include 'radar-auth:deprecated-auth0'

--- a/src/cucumberTest/java/cucumber/stepdefs/UserStepDefs.java
+++ b/src/cucumberTest/java/cucumber/stepdefs/UserStepDefs.java
@@ -9,8 +9,9 @@ import cucumber.api.java.Before;
 import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
 import javax.servlet.ServletException;
+
+import org.radarcns.auth.authentication.OAuthHelper;
 import org.radarcns.management.security.JwtAuthenticationFilter;
-import org.radarcns.management.web.rest.OAuthHelper;
 import org.radarcns.management.web.rest.UserResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;

--- a/src/main/java/org/radarcns/management/config/ManagementPortalProperties.java
+++ b/src/main/java/org/radarcns/management/config/ManagementPortalProperties.java
@@ -176,7 +176,7 @@ public class ManagementPortalProperties {
 
         private String metaTokenTimeout;
 
-        private Boolean enablePublicKeyVerifiers;
+        private Boolean enablePublicKeyVerifiers = false;
 
         public String getClientsFile() {
             return clientsFile;

--- a/src/main/java/org/radarcns/management/config/ManagementPortalProperties.java
+++ b/src/main/java/org/radarcns/management/config/ManagementPortalProperties.java
@@ -176,6 +176,8 @@ public class ManagementPortalProperties {
 
         private String metaTokenTimeout;
 
+        private Boolean enablePublicKeyVerifiers;
+
         public String getClientsFile() {
             return clientsFile;
         }
@@ -214,6 +216,14 @@ public class ManagementPortalProperties {
 
         public void setMetaTokenTimeout(String metaTokenTimeout) {
             this.metaTokenTimeout = metaTokenTimeout;
+        }
+
+        public Boolean getEnablePublicKeyVerifiers() {
+            return enablePublicKeyVerifiers;
+        }
+
+        public void setEnablePublicKeyVerifiers(Boolean enablePublicKeyVerifiers) {
+            this.enablePublicKeyVerifiers = enablePublicKeyVerifiers;
         }
     }
 

--- a/src/main/java/org/radarcns/management/config/OAuth2ServerConfiguration.java
+++ b/src/main/java/org/radarcns/management/config/OAuth2ServerConfiguration.java
@@ -209,7 +209,8 @@ public class OAuth2ServerConfiguration {
             logger.debug("loading token converter from keystore configurations");
             ManagementPortalOauthKeyStoreHandler keyFactory =
                     ManagementPortalOauthKeyStoreHandler.build(managementPortalProperties);
-            return new ManagementPortalJwtAccessTokenConverter(keyFactory.getAlgorithmForSigning());
+            return new ManagementPortalJwtAccessTokenConverter(keyFactory.getAlgorithmForSigning(),
+                    keyFactory.getVerifiers());
         }
 
         @Bean

--- a/src/main/java/org/radarcns/management/security/jwt/ManagementPortalOauthKeyStoreHandler.java
+++ b/src/main/java/org/radarcns/management/security/jwt/ManagementPortalOauthKeyStoreHandler.java
@@ -4,6 +4,7 @@ import static org.radarcns.management.security.jwt.ManagementPortalJwtAccessToke
 
 import java.io.IOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.security.KeyPair;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -66,6 +67,8 @@ public class ManagementPortalOauthKeyStoreHandler {
 
     private final List<String> verifierPublicKeys;
 
+    private final String managementPortalBaseUrl;
+
     /**
      * Keystore factory. This tries to load the first valid keystore listed in resources.
      *
@@ -82,6 +85,8 @@ public class ManagementPortalOauthKeyStoreHandler {
         this.store = loadStore();
         this.verifierPublicKeyAliasList = loadVerifiersPublicKeyAliasList();
         this.verifierPublicKeys = loadVerifyingPublicKeys();
+        this.managementPortalBaseUrl =
+                managementPortalProperties.getCommon().getManagementPortalBaseUrl();
 
     }
 
@@ -294,7 +299,13 @@ public class ManagementPortalOauthKeyStoreHandler {
         return new TokenValidatorConfig() {
             @Override
             public List<URI> getPublicKeyEndpoints() {
-                return Collections.emptyList();
+                try {
+                    URI managementPortalURL = new URI(managementPortalBaseUrl + "/oauth/token_key");
+                    return Collections.singletonList(managementPortalURL);
+                } catch (URISyntaxException e) {
+                    logger.error("Could not create publicKey end point URI");
+                    return Collections.emptyList();
+                }
             }
 
             @Override
@@ -304,7 +315,7 @@ public class ManagementPortalOauthKeyStoreHandler {
 
             @Override
             public List<String> getPublicKeys() {
-                return verifierPublicKeys;
+                return Collections.emptyList();
             }
         };
     }

--- a/src/main/java/org/radarcns/management/security/jwt/ManagementPortalOauthKeyStoreHandler.java
+++ b/src/main/java/org/radarcns/management/security/jwt/ManagementPortalOauthKeyStoreHandler.java
@@ -70,7 +70,7 @@ public class ManagementPortalOauthKeyStoreHandler {
 
     private String managementPortalBaseUrl;
 
-    private Boolean enableAdditionalPublicKeyVerifiers = false;
+    private final Boolean enableAdditionalPublicKeyVerifiers;
     
     private TokenValidatorConfig deprecatedValidatedConfig;
 

--- a/src/main/java/org/radarcns/management/security/jwt/ManagementPortalOauthKeyStoreHandler.java
+++ b/src/main/java/org/radarcns/management/security/jwt/ManagementPortalOauthKeyStoreHandler.java
@@ -76,6 +76,8 @@ public class ManagementPortalOauthKeyStoreHandler {
 
     private final List<JWTVerifier> verifiers = new ArrayList<>();
 
+    private final AlgorithmLoader algorithmLoader = new AlgorithmLoader();
+
 
     /**
      * Keystore factory. This tries to load the first valid keystore listed in resources.
@@ -110,7 +112,7 @@ public class ManagementPortalOauthKeyStoreHandler {
             if (deprecatedValidatedConfig != null) {
                 this.verifiers.addAll(deprecatedValidatedConfig.getPublicKeys()
                         .stream()
-                        .map(AlgorithmLoader::loadDeprecatedAlgorithmFromPublicKey)
+                        .map(algorithmLoader::loadDeprecatedAlgorithmFromPublicKey)
                         .filter(Objects::nonNull)
                         .map(algo -> AlgorithmLoader.buildVerifier(algo, RES_MANAGEMENT_PORTAL))
                         .collect(Collectors.toList()));

--- a/src/main/resources/config/application-dev.yml
+++ b/src/main/resources/config/application-dev.yml
@@ -97,7 +97,7 @@ server:
 managementportal:
     common:
         baseUrl: http://localhost:9000 # Modify according to your server's URL
-        managementPortalBaseUrl: http://localhost:9000
+        managementPortalBaseUrl: http://localhost:8080/
         privacyPolicyUrl: http://info.thehyve.nl/radar-cns-privacy-policy
         adminPassword: admin
         activationKeyTimeoutInSeconds: 86400 # 1 day

--- a/src/main/resources/config/application-prod.yml
+++ b/src/main/resources/config/application-prod.yml
@@ -93,7 +93,7 @@ server:
 managementportal:
     common:
         baseUrl: http://my-server-url-to-change-here # Modify according to your server's URL
-        managementPortalBaseUrl: http://my-server-url-to-change-here/
+        managementPortalBaseUrl: http://localhost:8080/managementportal
         privacyPolicyUrl: http://info.thehyve.nl/radar-cns-privacy-policy
         adminPassword:
         activationKeyTimeoutInSeconds: 86400

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -101,6 +101,7 @@ managementportal:
     oauth:
         keyStorePassword: radarbase
         signingKeyAlias: radarbase-managementportal-ec
+        enablePublicKeyVerifiers: false
 
 # ===================================================================
 # JHipster specific properties

--- a/src/test/java/org/radarcns/auth/authentication/OAuthHelper.java
+++ b/src/test/java/org/radarcns/auth/authentication/OAuthHelper.java
@@ -1,5 +1,7 @@
 package org.radarcns.auth.authentication;
 
+import static org.radarcns.management.security.jwt.ManagementPortalJwtAccessTokenConverter.RES_MANAGEMENT_PORTAL;
+
 import java.io.InputStream;
 import java.net.URI;
 import java.security.KeyStore;
@@ -40,6 +42,7 @@ public class OAuthHelper {
     public static final String[] AUTHORITIES = {"ROLE_SYS_ADMIN"};
     public static final String[] ROLES = {};
     public static final String[] SOURCES = {};
+    public static final String[] AUD = {RES_MANAGEMENT_PORTAL};
     public static final String CLIENT = "unit_test";
     public static final String USER = "admin";
     public static final String ISS = "RADAR";
@@ -167,6 +170,7 @@ public class OAuthHelper {
                 .withArrayClaim("authorities", AUTHORITIES)
                 .withArrayClaim("roles", ROLES)
                 .withArrayClaim("sources", SOURCES)
+                .withArrayClaim("aud", AUD)
                 .withClaim("client_id", CLIENT)
                 .withClaim("user_name", USER)
                 .withClaim("jti", JTI)

--- a/src/test/java/org/radarcns/management/security/JwtAuthenticationFilterIntTest.java
+++ b/src/test/java/org/radarcns/management/security/JwtAuthenticationFilterIntTest.java
@@ -6,7 +6,7 @@ import org.junit.runner.RunWith;
 import org.mockito.MockitoAnnotations;
 import org.radarcns.management.ManagementPortalTestApp;
 import org.radarcns.management.service.ProjectService;
-import org.radarcns.management.web.rest.OAuthHelper;
+import org.radarcns.auth.authentication.OAuthHelper;
 import org.radarcns.management.web.rest.ProjectResource;
 import org.radarcns.management.web.rest.errors.ExceptionTranslator;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/org/radarcns/management/web/rest/AuditResourceIntTest.java
+++ b/src/test/java/org/radarcns/management/web/rest/AuditResourceIntTest.java
@@ -10,6 +10,7 @@ import org.radarcns.management.domain.PersistentAuditEvent;
 import org.radarcns.management.repository.PersistenceAuditEventRepository;
 import org.radarcns.management.security.JwtAuthenticationFilter;
 import org.radarcns.management.service.AuditEventService;
+import org.radarcns.auth.authentication.OAuthHelper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;

--- a/src/test/java/org/radarcns/management/web/rest/ProjectResourceIntTest.java
+++ b/src/test/java/org/radarcns/management/web/rest/ProjectResourceIntTest.java
@@ -31,6 +31,7 @@ import org.radarcns.management.service.ProjectService;
 import org.radarcns.management.service.dto.ProjectDTO;
 import org.radarcns.management.service.mapper.ProjectMapper;
 import org.radarcns.management.web.rest.errors.ExceptionTranslator;
+import org.radarcns.auth.authentication.OAuthHelper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;

--- a/src/test/java/org/radarcns/management/web/rest/SourceDataResourceIntTest.java
+++ b/src/test/java/org/radarcns/management/web/rest/SourceDataResourceIntTest.java
@@ -27,6 +27,7 @@ import org.radarcns.management.service.SourceDataService;
 import org.radarcns.management.service.dto.SourceDataDTO;
 import org.radarcns.management.service.mapper.SourceDataMapper;
 import org.radarcns.management.web.rest.errors.ExceptionTranslator;
+import org.radarcns.auth.authentication.OAuthHelper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;

--- a/src/test/java/org/radarcns/management/web/rest/SourceResourceIntTest.java
+++ b/src/test/java/org/radarcns/management/web/rest/SourceResourceIntTest.java
@@ -33,6 +33,7 @@ import org.radarcns.management.service.dto.SourceTypeDTO;
 import org.radarcns.management.service.mapper.SourceMapper;
 import org.radarcns.management.service.mapper.SourceTypeMapper;
 import org.radarcns.management.web.rest.errors.ExceptionTranslator;
+import org.radarcns.auth.authentication.OAuthHelper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;

--- a/src/test/java/org/radarcns/management/web/rest/SourceTypeResourceIntTest.java
+++ b/src/test/java/org/radarcns/management/web/rest/SourceTypeResourceIntTest.java
@@ -32,6 +32,7 @@ import org.radarcns.management.service.dto.SourceTypeDTO;
 import org.radarcns.management.service.mapper.SourceDataMapper;
 import org.radarcns.management.service.mapper.SourceTypeMapper;
 import org.radarcns.management.web.rest.errors.ExceptionTranslator;
+import org.radarcns.auth.authentication.OAuthHelper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;

--- a/src/test/java/org/radarcns/management/web/rest/SubjectResourceIntTest.java
+++ b/src/test/java/org/radarcns/management/web/rest/SubjectResourceIntTest.java
@@ -51,6 +51,7 @@ import org.radarcns.management.service.dto.SourceTypeDTO;
 import org.radarcns.management.service.dto.SubjectDTO;
 import org.radarcns.management.service.mapper.SubjectMapper;
 import org.radarcns.management.web.rest.errors.ExceptionTranslator;
+import org.radarcns.auth.authentication.OAuthHelper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;

--- a/src/test/java/org/radarcns/management/web/rest/UserResourceIntTest.java
+++ b/src/test/java/org/radarcns/management/web/rest/UserResourceIntTest.java
@@ -17,6 +17,7 @@ import org.radarcns.management.service.UserService;
 import org.radarcns.management.service.dto.RoleDTO;
 import org.radarcns.management.web.rest.errors.ExceptionTranslator;
 import org.radarcns.management.web.rest.vm.ManagedUserVM;
+import org.radarcns.auth.authentication.OAuthHelper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;

--- a/src/test/resources/config/application.yml
+++ b/src/test/resources/config/application.yml
@@ -114,6 +114,6 @@ managementportal:
         metaTokenTimeout: 1H
     common:
         baseUrl: http://localhost:8080
-        managementPortalBaseUrl: http://localhost:9000
+        managementPortalBaseUrl: http://localhost:8080
         privacyPolicyUrl: http://info.thehyve.nl/radar-cns-privacy-policy
         activationKeyTimeoutInSeconds: 86400


### PR DESCRIPTION
- Adding deprecated `java-jwt:3.2.0` dependency to keep validating old tokens. 
- Deprecate configuring public-keys and use public-key endpoint.

**Changes for migration from 0.5.3 to 0.5.5**
When upgrading from versions earlier than 0.5.4, please follow these steps.
1. Copy old public-key file to MP class-path and configure environment variable `RADAR_IS_CONFIG_LOCATION` to the location of the config file provided.
2. Set `MANAGEMENTPORTAL_OAUTH_ENABLE_PUBLIC_KEY_VERIFIERS` to `"true"`.
3. If you have other components who validates the token, use the public-key endpoint to request for public-keys in the form of `JavaWebKeySet`. Please upgrade your `radar-auth` dependency to at lease `0.5.4` or higher.
