### PR TITLE
Add health check

### DIFF
--- a/src/main/java/org/radarcns/management/config/OAuth2ServerConfiguration.java
+++ b/src/main/java/org/radarcns/management/config/OAuth2ServerConfiguration.java
@@ -131,6 +131,7 @@ public class OAuth2ServerConfiguration {
                     .antMatchers("/api/register").hasAnyAuthority(AuthoritiesConstants.SYS_ADMIN)
                     .antMatchers("/api/profile-info").permitAll()
                     .antMatchers("/api/**").authenticated()
+                    .antMatchers("/management/health").permitAll()
                     .antMatchers("/management/**").hasAnyAuthority(AuthoritiesConstants.SYS_ADMIN)
                     .antMatchers("/v2/api-docs/**").permitAll()
                     .antMatchers("/swagger-resources/configuration/ui").permitAll()

--- a/src/main/java/org/radarcns/management/config/OAuth2ServerConfiguration.java
+++ b/src/main/java/org/radarcns/management/config/OAuth2ServerConfiguration.java
@@ -131,6 +131,8 @@ public class OAuth2ServerConfiguration {
                     .antMatchers("/api/register").hasAnyAuthority(AuthoritiesConstants.SYS_ADMIN)
                     .antMatchers("/api/profile-info").permitAll()
                     .antMatchers("/api/**").authenticated()
+                    // Allow management/health endpoint to all to allow kubernetes to be able to
+                    // detect the health of the service
                     .antMatchers("/management/health").permitAll()
                     .antMatchers("/management/**").hasAnyAuthority(AuthoritiesConstants.SYS_ADMIN)
                     .antMatchers("/v2/api-docs/**").permitAll()

--- a/src/main/java/org/radarcns/management/security/JwtAuthenticationFilter.java
+++ b/src/main/java/org/radarcns/management/security/JwtAuthenticationFilter.java
@@ -38,6 +38,13 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
             chain.doFilter(request, response);
             return;
         }
+
+        if(((HttpServletRequest) request).getRequestURI().contains("management/health")) {
+            log.debug("Skipping JWT check for Health check request");
+            chain.doFilter(request, response);
+            return;
+        }
+
         try {
             request.setAttribute(TOKEN_ATTRIBUTE,
                     validator.validateAccessToken(getToken(request, response)));
@@ -48,7 +55,12 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
             HttpServletResponse res = (HttpServletResponse) response;
             res.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
             res.setHeader(HttpHeaders.WWW_AUTHENTICATE, OAuth2AccessToken.BEARER_TYPE);
-            res.getOutputStream().println("{\"error\": \"" + ex.getMessage() + "\"}");
+            res.getOutputStream().println(
+                    "{\"error\": \"" + "Unauthorized" +",\n"
+                            + "\"status\": \"" +HttpServletResponse.SC_UNAUTHORIZED +",\n"
+                            + "\"message\": \"" + ex.getMessage() +",\n"
+                            + "\"path\": \"" + ((HttpServletRequest) request).getRequestURI() +"\n"
+                            + "\"}");
         }
     }
 

--- a/src/main/java/org/radarcns/management/security/JwtAuthenticationFilter.java
+++ b/src/main/java/org/radarcns/management/security/JwtAuthenticationFilter.java
@@ -39,7 +39,7 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
             return;
         }
 
-        if(((HttpServletRequest) request).getRequestURI().contains("management/health")) {
+        if (((HttpServletRequest) request).getRequestURI().contains("management/health")) {
             log.debug("Skipping JWT check for Health check request");
             chain.doFilter(request, response);
             return;
@@ -56,10 +56,10 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
             res.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
             res.setHeader(HttpHeaders.WWW_AUTHENTICATE, OAuth2AccessToken.BEARER_TYPE);
             res.getOutputStream().println(
-                    "{\"error\": \"" + "Unauthorized" +",\n"
-                            + "\"status\": \"" +HttpServletResponse.SC_UNAUTHORIZED +",\n"
-                            + "\"message\": \"" + ex.getMessage() +",\n"
-                            + "\"path\": \"" + ((HttpServletRequest) request).getRequestURI() +"\n"
+                    "{\"error\": \"" + "Unauthorized" + ",\n"
+                            + "\"status\": \"" + HttpServletResponse.SC_UNAUTHORIZED + ",\n"
+                            + "\"message\": \"" + ex.getMessage() + ",\n"
+                            + "\"path\": \"" + ((HttpServletRequest) request).getRequestURI() + "\n"
                             + "\"}");
         }
     }

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -39,10 +39,13 @@ hystrix:
 management:
     security:
         roles: ROLE_SYS_ADMIN
+        enabled: false
     context-path: /management
     health:
         mail:
             enabled: false # When using the MailService, configure an SMTP server and set this to true
+        db:
+            enabled: true
 spring:
     application:
         name: ManagementPortal

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -42,6 +42,8 @@ management:
         enabled: false
     context-path: /management
     health:
+        diskspace:
+            enabled: false
         mail:
             enabled: false # When using the MailService, configure an SMTP server and set this to true
         db:

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -39,11 +39,11 @@ hystrix:
 management:
     security:
         roles: ROLE_SYS_ADMIN
-        enabled: false
+        enabled: false # disabling security check for health to allow kubernetes to detect the health of the service
     context-path: /management
     health:
         diskspace:
-            enabled: false
+            enabled: false # disabling diskspace as the standard config, since we have removed security check for health endpoint
         mail:
             enabled: false # When using the MailService, configure an SMTP server and set this to true
         db:


### PR DESCRIPTION
Jhipster already added support for health-check using spring-actuator.
I have enabled the config to use database connection check and disable security checks for this specific call, to allow automatic health detection from docker/kubernetes health-check. 

The sample call and response are as follows:
```
curl 'http://localhost:9000/management/health' 
{
  "status" : "UP",
  "db" : {
    "status" : "UP",
    "database" : "H2",
    "hello" : 1
  },
  "refreshScope" : {
    "status" : "UP"
  },
  "hystrix" : {
    "status" : "UP"
  }
}
```

Fixes #440 #434 