### PR TITLE
Pair app dialog

### DIFF
--- a/src/main/java/org/radarcns/management/service/OAuthClientService.java
+++ b/src/main/java/org/radarcns/management/service/OAuthClientService.java
@@ -200,9 +200,11 @@ public class OAuthClientService {
 
         if (metaToken.getId() != null && metaToken.getTokenName() != null) {
             // get base url from settings
-            String baseUrl = managementPortalProperties.getCommon().getManagementPortalBaseUrl();
+            String baseUrl = managementPortalProperties.getCommon().getBaseUrl();
             // create complete uri string
-            String tokenUrl = baseUrl + ResourceUriService.getUri(metaToken).getPath();
+            String tokenUrl = managementPortalProperties.getCommon().getManagementPortalBaseUrl()
+                    + ResourceUriService.getUri(metaToken).getPath();
+
             // create response
             return new ClientPairInfoDTO(new URL(baseUrl), metaToken.getTokenName(),
                     new URL(tokenUrl), getMetaTokenTimeout());

--- a/src/main/java/org/radarcns/management/service/OAuthClientService.java
+++ b/src/main/java/org/radarcns/management/service/OAuthClientService.java
@@ -200,11 +200,9 @@ public class OAuthClientService {
 
         if (metaToken.getId() != null && metaToken.getTokenName() != null) {
             // get base url from settings
-            String baseUrl = managementPortalProperties.getCommon().getBaseUrl();
+            String baseUrl = managementPortalProperties.getCommon().getManagementPortalBaseUrl();
             // create complete uri string
-            String tokenUrl = managementPortalProperties.getCommon().getManagementPortalBaseUrl()
-                    + ResourceUriService.getUri(metaToken).getPath();
-
+            String tokenUrl = baseUrl + ResourceUriService.getUri(metaToken).getPath();
             // create response
             return new ClientPairInfoDTO(new URL(baseUrl), metaToken.getTokenName(),
                     new URL(tokenUrl), getMetaTokenTimeout());

--- a/src/main/webapp/app/shared/subject/subject-pair-dialog.component.html
+++ b/src/main/webapp/app/shared/subject/subject-pair-dialog.component.html
@@ -43,7 +43,7 @@
                 <tbody>
                 <tr>
                     <td>{{oauthClientPairInfo.baseUrl}}</td>
-                    <td>{{oauthClientPairInfo.tokenName}}</td>
+                    <td class="token">{{oauthClientPairInfo.tokenName}}</td>
                 </tr>
                 </tbody>
             </table>

--- a/src/main/webapp/app/shared/subject/subject-pair-dialog.component.scss
+++ b/src/main/webapp/app/shared/subject/subject-pair-dialog.component.scss
@@ -1,0 +1,3 @@
+td#token {
+    font-family: Consolas, Inconsolata, Monaco, "Lucida Console", monospace;
+}

--- a/src/main/webapp/app/shared/subject/subject-pair-dialog.component.ts
+++ b/src/main/webapp/app/shared/subject/subject-pair-dialog.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 
 import { NgbActiveModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
@@ -9,10 +9,12 @@ import { OAuthClientPairInfoService } from '../../entities/oauth-client/oauth-cl
 import { SubjectPopupService } from './subject-popup.service';
 import { Subject } from './subject.model';
 import { DatePipe } from '@angular/common';
+import { DOCUMENT } from '@angular/platform-browser';
 
 @Component({
     selector: 'jhi-subject-pair-dialog',
     templateUrl: './subject-pair-dialog.component.html',
+    styleUrls: ['./subject-pair-dialog.component.scss'],
     providers: [OAuthClientService, OAuthClientPairInfoService],
 })
 export class SubjectPairDialogComponent implements OnInit {
@@ -30,12 +32,14 @@ export class SubjectPairDialogComponent implements OnInit {
                 private alertService: AlertService,
                 private oauthClientService: OAuthClientService,
                 private oauthClientPairInfoService: OAuthClientPairInfoService,
-                private datePipe: DatePipe) {
+                private datePipe: DatePipe,
+                @Inject(DOCUMENT) private doc) {
         this.jhiLanguageService.addLocation('subject');
         this.authorities = ['ROLE_USER', 'ROLE_SYS_ADMIN'];
     }
 
     ngOnInit() {
+        this.loadInconsolataFont();
         this.oauthClientService.query().subscribe(
                 (res) => {
                     // only keep clients that have the dynamic_registration key in additionalInformation
@@ -44,6 +48,17 @@ export class SubjectPairDialogComponent implements OnInit {
                     .filter((c) => c.additionalInformation.dynamic_registration &&
                             c.additionalInformation.dynamic_registration.toLowerCase() === 'true');
                 });
+    }
+
+    private loadInconsolataFont() {
+        if (this.doc.getElementById('inconsolata-font-link') === null) {
+            const link: HTMLLinkElement = this.doc.createElement('link');
+            link.id = 'inconsolata-font-link';
+            link.setAttribute('rel', 'stylesheet');
+            link.setAttribute('type', 'text/css');
+            link.setAttribute('href', '//fonts.googleapis.com/css?family=Inconsolata');
+            this.doc.head.appendChild(link);
+        }
     }
 
     clear() {


### PR DESCRIPTION
Fixes #447.
- ~Use the configured base URL instead of the managementportal base url~
- Load the inconsolata font when the dialog is loaded. Do not load it more than once using a unique element ID.
- Specify that the token should use a monospaced font like Consolas, Inconsolata, Monaco or monospace.