### PR TITLE
Reduce api results

### DIFF
--- a/radar-auth/src/test/java/org/radarcns/auth/token/AbstractRadarTokenTest.java
+++ b/radar-auth/src/test/java/org/radarcns/auth/token/AbstractRadarTokenTest.java
@@ -17,11 +17,11 @@ import org.junit.Test;
 
 public class AbstractRadarTokenTest {
     static class MockToken extends AbstractRadarToken {
-        private Map<String, List<String>> roles = new HashMap<>();
-        private List<String> sources = new ArrayList<>();
-        private List<String> scopes = new ArrayList<>();
+        private final Map<String, List<String>> roles = new HashMap<>();
+        private final List<String> sources = new ArrayList<>();
+        private final List<String> scopes = new ArrayList<>();
         private String grantType = "refresh_token";
-        private List<String> authorities = new ArrayList<>();
+        private final List<String> authorities = new ArrayList<>();
         private String subject = null;
 
         @Override

--- a/radar-auth/src/test/java/org/radarcns/auth/token/AbstractRadarTokenTest.java
+++ b/radar-auth/src/test/java/org/radarcns/auth/token/AbstractRadarTokenTest.java
@@ -1,0 +1,203 @@
+package org.radarcns.auth.token;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.radarcns.auth.authorization.AuthoritiesConstants.PARTICIPANT;
+import static org.radarcns.auth.authorization.AuthoritiesConstants.SYS_ADMIN;
+import static org.radarcns.auth.authorization.Permission.MEASUREMENT_CREATE;
+import static org.radarcns.auth.token.AbstractRadarToken.CLIENT_CREDENTIALS;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+
+public class AbstractRadarTokenTest {
+    static class MockToken extends AbstractRadarToken {
+        private Map<String, List<String>> roles = new HashMap<>();
+        private List<String> sources = new ArrayList<>();
+        private List<String> scopes = new ArrayList<>();
+        private String grantType = "refresh_token";
+        private List<String> authorities = new ArrayList<>();
+        private String subject = null;
+
+        @Override
+        public Map<String, List<String>> getRoles() {
+            return roles;
+        }
+
+        @Override
+        public List<String> getAuthorities() {
+            return authorities;
+        }
+
+        @Override
+        public List<String> getScopes() {
+            return scopes;
+        }
+
+        @Override
+        public List<String> getSources() {
+            return sources;
+        }
+
+        @Override
+        public String getGrantType() {
+            return grantType;
+        }
+
+        @Override
+        public String getSubject() {
+            return subject;
+        }
+
+        @Override
+        public Date getIssuedAt() {
+            return null;
+        }
+
+        @Override
+        public Date getExpiresAt() {
+            return null;
+        }
+
+        @Override
+        public List<String> getAudience() {
+            return null;
+        }
+
+        @Override
+        public String getToken() {
+            return null;
+        }
+
+        @Override
+        public String getIssuer() {
+            return null;
+        }
+
+        @Override
+        public String getType() {
+            return null;
+        }
+    }
+
+    @Test
+    public void notHasPermissionWithoutScope() {
+        MockToken token = new MockToken();
+        assertFalse(token.hasPermission(MEASUREMENT_CREATE));
+    }
+
+    @Test
+    public void notHasPermissionWithoutAuthority() {
+        MockToken token = new MockToken();
+        token.scopes.add("MEASUREMENT_CREATE");
+        assertFalse(token.hasPermission(MEASUREMENT_CREATE));
+    }
+
+    @Test
+    public void hasPermissionAsAdmin() {
+        MockToken token = new MockToken();
+        token.scopes.add(MEASUREMENT_CREATE.scopeName());
+        token.authorities.add(SYS_ADMIN);
+        assertTrue(token.hasPermission(MEASUREMENT_CREATE));
+    }
+
+    @Test
+    public void hasPermissionAsUser() {
+        MockToken token = new MockToken();
+        token.scopes.add(MEASUREMENT_CREATE.scopeName());
+        token.roles.put("some", Collections.singletonList(PARTICIPANT));
+        assertTrue(token.hasPermission(MEASUREMENT_CREATE));
+    }
+
+    @Test
+    public void hasPermissionAsClient() {
+        MockToken token = new MockToken();
+        token.scopes.add(MEASUREMENT_CREATE.scopeName());
+        token.grantType = CLIENT_CREDENTIALS;
+        assertTrue(token.hasPermission(MEASUREMENT_CREATE));
+    }
+
+    @Test
+    public void notHasPermissionOnProjectWithoutScope() {
+        MockToken token = new MockToken();
+        assertFalse(token.hasPermissionOnProject(MEASUREMENT_CREATE, "project"));
+    }
+
+    @Test
+    public void notHasPermissioOnProjectnWithoutAuthority() {
+        MockToken token = new MockToken();
+        token.scopes.add("MEASUREMENT_CREATE");
+        assertFalse(token.hasPermissionOnProject(MEASUREMENT_CREATE, "project"));
+    }
+
+    @Test
+    public void hasPermissionOnProjectAsAdmin() {
+        MockToken token = new MockToken();
+        token.scopes.add(MEASUREMENT_CREATE.scopeName());
+        token.authorities.add(SYS_ADMIN);
+        assertTrue(token.hasPermissionOnProject(MEASUREMENT_CREATE, "project"));
+    }
+
+    @Test
+    public void hasPermissionOnProjectAsUser() {
+        MockToken token = new MockToken();
+        token.scopes.add(MEASUREMENT_CREATE.scopeName());
+        token.roles.put("project", Collections.singletonList(PARTICIPANT));
+        assertTrue(token.hasPermissionOnProject(MEASUREMENT_CREATE, "project"));
+        assertFalse(token.hasPermissionOnProject(MEASUREMENT_CREATE, "otherProject"));
+    }
+
+    @Test
+    public void hasPermissionOnProjectAsClient() {
+        MockToken token = new MockToken();
+        token.scopes.add(MEASUREMENT_CREATE.scopeName());
+        token.grantType = CLIENT_CREDENTIALS;
+        assertTrue(token.hasPermissionOnProject(MEASUREMENT_CREATE, "project"));
+    }
+
+
+    @Test
+    public void notHasPermissionOnSubjectWithoutScope() {
+        MockToken token = new MockToken();
+        assertFalse(token.hasPermissionOnSubject(MEASUREMENT_CREATE, "project", "subject"));
+    }
+
+    @Test
+    public void notHasPermissioOnSubjectnWithoutAuthority() {
+        MockToken token = new MockToken();
+        token.scopes.add("MEASUREMENT_CREATE");
+        assertFalse(token.hasPermissionOnSubject(MEASUREMENT_CREATE, "project", "subject"));
+    }
+
+    @Test
+    public void hasPermissionOnSubjectAsAdmin() {
+        MockToken token = new MockToken();
+        token.scopes.add(MEASUREMENT_CREATE.scopeName());
+        token.authorities.add(SYS_ADMIN);
+        assertTrue(token.hasPermissionOnSubject(MEASUREMENT_CREATE, "project", "subject"));
+    }
+
+    @Test
+    public void hasPermissionOnSubjectAsUser() {
+        MockToken token = new MockToken();
+        token.scopes.add(MEASUREMENT_CREATE.scopeName());
+        token.roles.put("project", Collections.singletonList(PARTICIPANT));
+        token.subject = "subject";
+        assertTrue(token.hasPermissionOnSubject(MEASUREMENT_CREATE, "project", "subject"));
+        assertFalse(token.hasPermissionOnSubject(MEASUREMENT_CREATE, "otherProject", "subject"));
+        assertFalse(token.hasPermissionOnSubject(MEASUREMENT_CREATE, "project", "otherSubject"));
+    }
+
+    @Test
+    public void hasPermissionOnSubjectAsClient() {
+        MockToken token = new MockToken();
+        token.scopes.add(MEASUREMENT_CREATE.scopeName());
+        token.grantType = CLIENT_CREDENTIALS;
+        assertTrue(token.hasPermissionOnSubject(MEASUREMENT_CREATE, "project", "subject"));
+    }
+}

--- a/src/main/java/org/radarcns/management/domain/Project.java
+++ b/src/main/java/org/radarcns/management/domain/Project.java
@@ -81,7 +81,7 @@ public class Project extends AbstractEntity implements Serializable {
     private ZonedDateTime endDate;
 
     @JsonIgnore
-    @OneToMany(mappedBy = "project")
+    @OneToMany(mappedBy = "project", fetch = FetchType.LAZY)
     @Cascade(org.hibernate.annotations.CascadeType.ALL)
     private Set<Role> roles;
 

--- a/src/main/java/org/radarcns/management/domain/Project.java
+++ b/src/main/java/org/radarcns/management/domain/Project.java
@@ -85,7 +85,7 @@ public class Project extends AbstractEntity implements Serializable {
     @Cascade(org.hibernate.annotations.CascadeType.ALL)
     private Set<Role> roles;
 
-    @ManyToMany(fetch = FetchType.EAGER)
+    @ManyToMany(fetch = FetchType.LAZY)
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @JoinTable(name = "project_source_type",
             joinColumns = @JoinColumn(name = "projects_id", referencedColumnName = "id"),

--- a/src/main/java/org/radarcns/management/domain/Role.java
+++ b/src/main/java/org/radarcns/management/domain/Role.java
@@ -9,6 +9,7 @@ package org.radarcns.management.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.persistence.FetchType;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.envers.Audited;
@@ -47,18 +48,18 @@ public class Role extends AbstractEntity implements Serializable {
     @SequenceGenerator(name = "sequenceGenerator", initialValue = 1000)
     private Long id;
 
-    @ManyToMany(mappedBy = "roles")
+    @ManyToMany(mappedBy = "roles", fetch = FetchType.LAZY)
     @JsonIgnore
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @Audited(targetAuditMode = RelationTargetAuditMode.NOT_AUDITED)
     private Set<User> users = new HashSet<>();
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.EAGER)
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private Project project;
 
     @JsonProperty()
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.EAGER)
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @JoinColumn(name = "authority_name", referencedColumnName = "name")
     private Authority authority;

--- a/src/main/java/org/radarcns/management/domain/Role.java
+++ b/src/main/java/org/radarcns/management/domain/Role.java
@@ -54,6 +54,7 @@ public class Role extends AbstractEntity implements Serializable {
     private Set<User> users = new HashSet<>();
 
     @ManyToOne
+    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private Project project;
 
     @JsonProperty()

--- a/src/main/java/org/radarcns/management/domain/Source.java
+++ b/src/main/java/org/radarcns/management/domain/Source.java
@@ -63,16 +63,16 @@ public class Source extends AbstractEntity implements Serializable {
     @Column(name = "assigned", nullable = false)
     private Boolean assigned;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "subject_id")
     @JsonIgnore
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private Subject subject;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.EAGER)
     private SourceType sourceType;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private Project project;
 
     @ElementCollection(fetch = FetchType.EAGER)

--- a/src/main/java/org/radarcns/management/domain/SourceType.java
+++ b/src/main/java/org/radarcns/management/domain/SourceType.java
@@ -1,6 +1,7 @@
 package org.radarcns.management.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import javax.persistence.FetchType;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.Cascade;
@@ -82,12 +83,12 @@ public class SourceType extends AbstractEntity implements Serializable {
     @Column(name = "dynamic_registration", nullable = false)
     private Boolean canRegisterDynamically = false;
 
-    @OneToMany(mappedBy = "sourceType", orphanRemoval = true)
+    @OneToMany(mappedBy = "sourceType", orphanRemoval = true, fetch = FetchType.LAZY)
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @Cascade({CascadeType.DELETE, CascadeType.SAVE_UPDATE})
     private Set<SourceData> sourceData;
 
-    @ManyToMany(mappedBy = "sourceTypes")
+    @ManyToMany(mappedBy = "sourceTypes", fetch = FetchType.LAZY)
     @JsonIgnore
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private Set<Project> projects = new HashSet<>();

--- a/src/main/java/org/radarcns/management/domain/SourceType.java
+++ b/src/main/java/org/radarcns/management/domain/SourceType.java
@@ -15,7 +15,6 @@ import javax.persistence.Entity;
 import javax.persistence.EntityListeners;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
-import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -83,7 +82,7 @@ public class SourceType extends AbstractEntity implements Serializable {
     @Column(name = "dynamic_registration", nullable = false)
     private Boolean canRegisterDynamically = false;
 
-    @OneToMany(mappedBy = "sourceType", fetch = FetchType.EAGER, orphanRemoval = true)
+    @OneToMany(mappedBy = "sourceType", orphanRemoval = true)
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @Cascade({CascadeType.DELETE, CascadeType.SAVE_UPDATE})
     private Set<SourceData> sourceData;

--- a/src/main/java/org/radarcns/management/domain/Subject.java
+++ b/src/main/java/org/radarcns/management/domain/Subject.java
@@ -66,7 +66,7 @@ public class Subject extends AbstractEntity implements Serializable {
     @Cascade(CascadeType.ALL)
     private User user;
 
-    @OneToMany(mappedBy = "subject")
+    @OneToMany(mappedBy = "subject", fetch = FetchType.LAZY)
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @Cascade(CascadeType.SAVE_UPDATE)
     private Set<Source> sources = new HashSet<>();
@@ -78,7 +78,7 @@ public class Subject extends AbstractEntity implements Serializable {
     @Cascade(CascadeType.ALL)
     private Map<String, String> attributes = new HashMap<>();
 
-    @OneToMany(mappedBy = "subject", orphanRemoval = true)
+    @OneToMany(mappedBy = "subject", orphanRemoval = true, fetch = FetchType.LAZY)
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @JsonIgnore
     private final Set<MetaToken> metaTokens = new HashSet<>();

--- a/src/main/java/org/radarcns/management/repository/ProjectRepository.java
+++ b/src/main/java/org/radarcns/management/repository/ProjectRepository.java
@@ -27,7 +27,7 @@ public interface ProjectRepository extends JpaRepository<Project, Long>,
     Page<Project> findAllWithEagerRelationships(Pageable pageable);
 
     @Query("select project from Project project left join fetch "
-            + "project.sourceTypes where project.id =:id")
+            + "project.sourceTypes s left join fetch s.sourceData where project.id =:id")
     Optional<Project> findOneWithEagerRelationships(@Param("id") Long id);
 
     @Query("select project from Project project left join fetch "

--- a/src/main/java/org/radarcns/management/service/ProjectService.java
+++ b/src/main/java/org/radarcns/management/service/ProjectService.java
@@ -64,7 +64,7 @@ public class ProjectService {
     public Page findAll(Boolean fetchMinimal, Pageable pageable) {
         Page<Project> projects = projectRepository.findAllWithEagerRelationships(pageable);
         if (!fetchMinimal) {
-            return projects.map(projectMapper::projectToProjectDTOWithoutSources);
+            return projects.map(projectMapper::projectToProjectDTOReduced);
         } else {
             return projects.map(projectMapper::projectToMinimalProjectDetailsDTO);
         }

--- a/src/main/java/org/radarcns/management/service/ProjectService.java
+++ b/src/main/java/org/radarcns/management/service/ProjectService.java
@@ -52,8 +52,7 @@ public class ProjectService {
         log.debug("Request to save Project : {}", projectDto);
         Project project = projectMapper.projectDTOToProject(projectDto);
         project = projectRepository.save(project);
-        ProjectDTO result = projectMapper.projectToProjectDTO(project);
-        return result;
+        return projectMapper.projectToProjectDTO(project);
     }
 
     /**
@@ -65,7 +64,7 @@ public class ProjectService {
     public Page findAll(Boolean fetchMinimal, Pageable pageable) {
         Page<Project> projects = projectRepository.findAllWithEagerRelationships(pageable);
         if (!fetchMinimal) {
-            return projects.map(projectMapper::projectToProjectDTO);
+            return projects.map(projectMapper::projectToProjectDTOWithoutSources);
         } else {
             return projects.map(projectMapper::projectToMinimalProjectDetailsDTO);
         }

--- a/src/main/java/org/radarcns/management/service/RoleService.java
+++ b/src/main/java/org/radarcns/management/service/RoleService.java
@@ -7,7 +7,6 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import org.radarcns.auth.authorization.AuthoritiesConstants;
 import org.radarcns.management.domain.Authority;
-import org.radarcns.management.domain.Project;
 import org.radarcns.management.domain.Role;
 import org.radarcns.management.domain.User;
 import org.radarcns.management.repository.RoleRepository;

--- a/src/main/java/org/radarcns/management/service/SourceDataService.java
+++ b/src/main/java/org/radarcns/management/service/SourceDataService.java
@@ -44,8 +44,7 @@ public class SourceDataService {
         log.debug("Request to save SourceData : {}", sourceDataDto);
         SourceData sourceData = sourceDataMapper.sourceDataDTOToSourceData(sourceDataDto);
         sourceData = sourceDataRepository.save(sourceData);
-        SourceDataDTO result = sourceDataMapper.sourceDataToSourceDataDTO(sourceData);
-        return result;
+        return sourceDataMapper.sourceDataToSourceDataDTO(sourceData);
     }
 
     /**
@@ -85,8 +84,7 @@ public class SourceDataService {
     public SourceDataDTO findOne(Long id) {
         log.debug("Request to get SourceData : {}", id);
         SourceData sourceData = sourceDataRepository.findOne(id);
-        SourceDataDTO sourceDataDto = sourceDataMapper.sourceDataToSourceDataDTO(sourceData);
-        return sourceDataDto;
+        return sourceDataMapper.sourceDataToSourceDataDTO(sourceData);
     }
 
     /**

--- a/src/main/java/org/radarcns/management/service/SourceService.java
+++ b/src/main/java/org/radarcns/management/service/SourceService.java
@@ -147,7 +147,7 @@ public class SourceService {
      */
     public Page<SourceDTO> findAllByProjectId(Long projectId, Pageable pageable) {
         return sourceRepository.findAllSourcesByProjectId(pageable, projectId)
-                .map(sourceMapper::sourceToSourceDTO);
+                .map(sourceMapper::sourceToSourceWithoutProjectDTO);
     }
 
     /**

--- a/src/main/java/org/radarcns/management/service/UserService.java
+++ b/src/main/java/org/radarcns/management/service/UserService.java
@@ -6,7 +6,6 @@ import static org.radarcns.management.web.rest.errors.EntityName.USER;
 
 import java.time.Period;
 import java.time.ZonedDateTime;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;

--- a/src/main/java/org/radarcns/management/service/UserService.java
+++ b/src/main/java/org/radarcns/management/service/UserService.java
@@ -11,10 +11,12 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
+import java.util.stream.Collectors;
 import org.radarcns.auth.authorization.AuthoritiesConstants;
 import org.radarcns.auth.config.Constants;
 import org.radarcns.management.config.ManagementPortalProperties;
@@ -327,18 +329,21 @@ public class UserService {
      */
     @Transactional(readOnly = true)
     public List<ProjectDTO> getProjectsAssignedToUser(String login) {
-        User userByLogin = userRepository.findOneWithRolesByLogin(login).get();
-        List<Project> projectsOfUser = new ArrayList<>();
-        for (Role role : userByLogin.getRoles()) {
-            // get all projects for admin
-            if (AuthoritiesConstants.SYS_ADMIN.equals(role.getAuthority().getName())) {
-                return projectMapper.projectsToProjectDTOs(projectRepository.findAll());
-            }
-            // get unique project from roles
-            if (!projectsOfUser.contains(role.getProject())) {
-                projectsOfUser.add(role.getProject());
-            }
+        User userByLogin = userRepository.findOneWithRolesByLogin(login)
+                .orElseThrow(NoSuchElementException::new);
+
+        List<Project> projectsOfUser;
+
+        if (userByLogin.getRoles().stream()
+                .anyMatch(r -> AuthoritiesConstants.SYS_ADMIN.equals(r.getAuthority().getName()))) {
+            projectsOfUser = projectRepository.findAll();
+        } else {
+            projectsOfUser = userByLogin.getRoles().stream()
+                    .map(Role::getProject)
+                    .distinct()
+                    .collect(Collectors.toList());
         }
+
         return projectMapper.projectsToProjectDTOs(projectsOfUser);
     }
 

--- a/src/main/java/org/radarcns/management/service/dto/ProjectDTO.java
+++ b/src/main/java/org/radarcns/management/service/dto/ProjectDTO.java
@@ -1,25 +1,20 @@
 package org.radarcns.management.service.dto;
 
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import java.io.Serializable;
 import java.time.ZonedDateTime;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import javax.validation.constraints.NotNull;
 import org.radarcns.management.domain.enumeration.ProjectStatus;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A DTO for the Project entity.
  */
 public class ProjectDTO implements Serializable {
-    private static final Logger logger = LoggerFactory.getLogger(ProjectDTO.class);
     private static final long serialVersionUID = 1L;
 
     public static final String EXTERNAL_PROJECT_URL_KEY = "External-project-url";
@@ -124,7 +119,6 @@ public class ProjectDTO implements Serializable {
     }
 
     public void setSourceTypes(Set<SourceTypeDTO> sourceTypes) {
-        logger.info("Set source types to {}", sourceTypes);
         this.sourceTypes = sourceTypes;
     }
 

--- a/src/main/java/org/radarcns/management/service/dto/ProjectDTO.java
+++ b/src/main/java/org/radarcns/management/service/dto/ProjectDTO.java
@@ -1,6 +1,9 @@
 package org.radarcns.management.service.dto;
 
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import java.io.Serializable;
 import java.time.ZonedDateTime;
 import java.util.HashSet;
@@ -9,12 +12,14 @@ import java.util.Objects;
 import java.util.Set;
 import javax.validation.constraints.NotNull;
 import org.radarcns.management.domain.enumeration.ProjectStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A DTO for the Project entity.
  */
 public class ProjectDTO implements Serializable {
-
+    private static final Logger logger = LoggerFactory.getLogger(ProjectDTO.class);
     private static final long serialVersionUID = 1L;
 
     public static final String EXTERNAL_PROJECT_URL_KEY = "External-project-url";
@@ -45,7 +50,8 @@ public class ProjectDTO implements Serializable {
 
     private ZonedDateTime endDate;
 
-    private Set<SourceTypeDTO> sourceTypes = new HashSet<>();
+    @JsonInclude(Include.NON_NULL)
+    private Set<SourceTypeDTO> sourceTypes;
 
     private Map<String, String> attributes;
 
@@ -118,6 +124,7 @@ public class ProjectDTO implements Serializable {
     }
 
     public void setSourceTypes(Set<SourceTypeDTO> sourceTypes) {
+        logger.info("Set source types to {}", sourceTypes);
         this.sourceTypes = sourceTypes;
     }
 

--- a/src/main/java/org/radarcns/management/service/dto/SourceDTO.java
+++ b/src/main/java/org/radarcns/management/service/dto/SourceDTO.java
@@ -1,6 +1,8 @@
 package org.radarcns.management.service.dto;
 
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import java.io.Serializable;
 import java.util.Map;
 import java.util.Objects;
@@ -31,6 +33,7 @@ public class SourceDTO implements Serializable {
 
     private String subjectLogin;
 
+    @JsonInclude(Include.NON_NULL)
     private MinimalProjectDetailsDTO project;
 
     private Map<String, String> attributes;

--- a/src/main/java/org/radarcns/management/service/dto/SourceDataDTO.java
+++ b/src/main/java/org/radarcns/management/service/dto/SourceDataDTO.java
@@ -1,6 +1,8 @@
 package org.radarcns.management.service.dto;
 
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import java.io.Serializable;
 import java.util.Objects;
 import javax.validation.constraints.NotNull;
@@ -44,6 +46,7 @@ public class SourceDataDTO implements Serializable {
 
     private boolean enabled = true;
 
+    @JsonInclude(Include.NON_NULL)
     private MinimalSourceTypeDTO sourceType;
 
     public Long getId() {

--- a/src/main/java/org/radarcns/management/service/dto/SubjectDTO.java
+++ b/src/main/java/org/radarcns/management/service/dto/SubjectDTO.java
@@ -1,6 +1,8 @@
 package org.radarcns.management.service.dto;
 
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import java.io.Serializable;
 import java.time.ZonedDateTime;
 import java.util.HashMap;
@@ -45,6 +47,7 @@ public class SubjectDTO implements Serializable {
 
     private ZonedDateTime lastModifiedDate;
 
+    @JsonInclude(Include.NON_NULL)
     private ProjectDTO project;
 
     private List<RoleDTO> roles;

--- a/src/main/java/org/radarcns/management/service/dto/SubjectDTO.java
+++ b/src/main/java/org/radarcns/management/service/dto/SubjectDTO.java
@@ -39,12 +39,16 @@ public class SubjectDTO implements Serializable {
 
     private SubjectStatus status = SubjectStatus.DEACTIVATED;
 
+    @JsonInclude(Include.NON_NULL)
     private String createdBy;
 
+    @JsonInclude(Include.NON_NULL)
     private ZonedDateTime createdDate;
 
+    @JsonInclude(Include.NON_NULL)
     private String lastModifiedBy;
 
+    @JsonInclude(Include.NON_NULL)
     private ZonedDateTime lastModifiedDate;
 
     @JsonInclude(Include.NON_NULL)

--- a/src/main/java/org/radarcns/management/service/mapper/ProjectMapper.java
+++ b/src/main/java/org/radarcns/management/service/mapper/ProjectMapper.java
@@ -2,8 +2,10 @@ package org.radarcns.management.service.mapper;
 
 import java.util.List;
 import org.mapstruct.DecoratedWith;
+import org.mapstruct.IterableMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.Named;
 import org.radarcns.management.domain.Project;
 import org.radarcns.management.service.dto.MinimalProjectDetailsDTO;
 import org.radarcns.management.service.dto.ProjectDTO;
@@ -19,10 +21,12 @@ public interface ProjectMapper {
     @Mapping(target = "humanReadableProjectName", ignore = true)
     ProjectDTO projectToProjectDTO(Project project);
 
+    @Named(value = "projectReducedDTO")
     @Mapping(target = "humanReadableProjectName", ignore = true)
     @Mapping(target = "sourceTypes", ignore = true)
-    ProjectDTO projectToProjectDTOWithoutSources(Project project);
+    ProjectDTO projectToProjectDTOReduced(Project project);
 
+    @IterableMapping(qualifiedByName = "projectReducedDTO")
     List<ProjectDTO> projectsToProjectDTOs(List<Project> projects);
 
     @Mapping(target = "roles", ignore = true)

--- a/src/main/java/org/radarcns/management/service/mapper/ProjectMapper.java
+++ b/src/main/java/org/radarcns/management/service/mapper/ProjectMapper.java
@@ -19,6 +19,10 @@ public interface ProjectMapper {
     @Mapping(target = "humanReadableProjectName", ignore = true)
     ProjectDTO projectToProjectDTO(Project project);
 
+    @Mapping(target = "humanReadableProjectName", ignore = true)
+    @Mapping(target = "sourceTypes", ignore = true)
+    ProjectDTO projectToProjectDTOWithoutSources(Project project);
+
     List<ProjectDTO> projectsToProjectDTOs(List<Project> projects);
 
     @Mapping(target = "roles", ignore = true)

--- a/src/main/java/org/radarcns/management/service/mapper/SourceDataMapper.java
+++ b/src/main/java/org/radarcns/management/service/mapper/SourceDataMapper.java
@@ -1,6 +1,9 @@
 package org.radarcns.management.service.mapper;
 
+import org.mapstruct.IterableMapping;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
 import org.radarcns.management.domain.SourceData;
 import org.radarcns.management.service.dto.SourceDataDTO;
 
@@ -12,8 +15,14 @@ import java.util.List;
 @Mapper(componentModel = "spring", uses = {SourceTypeMapper.class})
 public interface SourceDataMapper {
 
+    @Named("sourceDataDTO")
     SourceDataDTO sourceDataToSourceDataDTO(SourceData sourceData);
 
+    @Named("sourceDataReducedDTO")
+    @Mapping(target = "sourceType", ignore = true)
+    SourceDataDTO sourceDataToSourceDataDTOReduced(SourceData sourceData);
+
+    @IterableMapping(qualifiedByName = "sourceDataReducedDTO")
     List<SourceDataDTO> sourceDataToSourceDataDTOs(List<SourceData> sourceData);
 
     SourceData sourceDataDTOToSourceData(SourceDataDTO sourceDataDto);

--- a/src/main/java/org/radarcns/management/service/mapper/SourceMapper.java
+++ b/src/main/java/org/radarcns/management/service/mapper/SourceMapper.java
@@ -1,8 +1,10 @@
 package org.radarcns.management.service.mapper;
 
 import org.mapstruct.DecoratedWith;
+import org.mapstruct.IterableMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.Named;
 import org.radarcns.management.domain.Source;
 import org.radarcns.management.service.dto.MinimalSourceDetailsDTO;
 import org.radarcns.management.service.dto.SourceDTO;
@@ -20,6 +22,14 @@ public interface SourceMapper {
     @Mapping(source = "source.subject.user.login", target = "subjectLogin")
     SourceDTO sourceToSourceDTO(Source source);
 
+    @Named("sourceWithoutProjectDTO")
+    @Mapping(source = "source.subject.user.login", target = "subjectLogin")
+    @Mapping(target = "project", ignore = true)
+    SourceDTO sourceToSourceWithoutProjectDTO(Source source);
+
+    @IterableMapping(qualifiedByName = "sourceWithoutProjectDTO")
+    List<SourceDTO> sourcesToSourceDTOs(List<Source> sources);
+
     @Mapping(source = "sourceType.id", target = "sourceTypeId")
     @Mapping(source = "sourceType.producer", target = "sourceTypeProducer")
     @Mapping(source = "sourceType.model", target = "sourceTypeModel")
@@ -33,8 +43,6 @@ public interface SourceMapper {
     @Mapping(target = "project", ignore = true)
     @Mapping(target = "subject", ignore = true)
     Source descriptiveDTOToSource(MinimalSourceDetailsDTO minimalSourceDetailsDto);
-
-    List<SourceDTO> sourcesToSourceDTOs(List<Source> sources);
 
     @Mapping(target = "subject", ignore = true)
     Source sourceDTOToSource(SourceDTO sourceDto);

--- a/src/main/java/org/radarcns/management/service/mapper/SourceTypeMapper.java
+++ b/src/main/java/org/radarcns/management/service/mapper/SourceTypeMapper.java
@@ -1,10 +1,14 @@
 package org.radarcns.management.service.mapper;
 
 import java.util.List;
+import java.util.Set;
+import org.mapstruct.IterableMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.radarcns.management.domain.SourceData;
 import org.radarcns.management.domain.SourceType;
 import org.radarcns.management.service.dto.MinimalSourceTypeDTO;
+import org.radarcns.management.service.dto.SourceDataDTO;
 import org.radarcns.management.service.dto.SourceTypeDTO;
 
 /**
@@ -26,6 +30,9 @@ public interface SourceTypeMapper {
 
     List<MinimalSourceTypeDTO> sourceTypesToMinimalSourceTypeDetailsDTOs(
             List<SourceType> sourceTypes);
+
+    @IterableMapping(qualifiedByName = "sourceDataReducedDTO")
+    Set<SourceDataDTO> map(Set<SourceData> sourceData);
 
     @Mapping(target = "sourceTypeScope", ignore = true)
     @Mapping(target = "sourceData", ignore = true)

--- a/src/main/java/org/radarcns/management/service/mapper/SubjectMapper.java
+++ b/src/main/java/org/radarcns/management/service/mapper/SubjectMapper.java
@@ -27,6 +27,16 @@ public interface SubjectMapper {
     @Mapping(source = "user.roles", target = "roles")
     SubjectDTO subjectToSubjectDTO(Subject subject);
 
+    @Mapping(source = "user.login", target = "login")
+    @Mapping(target = "status", ignore = true)
+    @Mapping(target = "project", ignore = true)
+    @Mapping(target = "createdBy", ignore = true)
+    @Mapping(target = "createdDate", ignore = true)
+    @Mapping(target = "lastModifiedBy", ignore = true)
+    @Mapping(target = "lastModifiedDate", ignore = true)
+    @Mapping(source = "user.roles", target = "roles")
+    SubjectDTO subjectToSubjectDTOWithoutProject(Subject subject);
+
     List<SubjectDTO> subjectsToSubjectDTOs(List<Subject> subjects);
 
     @Mapping(source = "login", target = "user.login")

--- a/src/main/java/org/radarcns/management/service/mapper/SubjectMapper.java
+++ b/src/main/java/org/radarcns/management/service/mapper/SubjectMapper.java
@@ -1,14 +1,12 @@
 package org.radarcns.management.service.mapper;
 
 import java.util.List;
-import javax.ws.rs.core.Context;
 import org.mapstruct.DecoratedWith;
 import org.mapstruct.IterableMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
 import org.mapstruct.Named;
-import org.radarcns.management.domain.Project;
 import org.radarcns.management.domain.Subject;
 import org.radarcns.management.service.dto.SubjectDTO;
 import org.radarcns.management.service.mapper.decorator.SubjectMapperDecorator;

--- a/src/main/java/org/radarcns/management/service/mapper/SubjectMapper.java
+++ b/src/main/java/org/radarcns/management/service/mapper/SubjectMapper.java
@@ -2,9 +2,11 @@ package org.radarcns.management.service.mapper;
 
 import java.util.List;
 import org.mapstruct.DecoratedWith;
+import org.mapstruct.IterableMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
+import org.mapstruct.Named;
 import org.radarcns.management.domain.Subject;
 import org.radarcns.management.service.dto.SubjectDTO;
 import org.radarcns.management.service.mapper.decorator.SubjectMapperDecorator;
@@ -35,9 +37,21 @@ public interface SubjectMapper {
     @Mapping(target = "lastModifiedBy", ignore = true)
     @Mapping(target = "lastModifiedDate", ignore = true)
     @Mapping(source = "user.roles", target = "roles")
-    SubjectDTO subjectToSubjectDTOWithoutProject(Subject subject);
+    SubjectDTO subjectToSubjectReducedProjectDTO(Subject subject);
 
-    List<SubjectDTO> subjectsToSubjectDTOs(List<Subject> subjects);
+    @Named(value = "subjectReducedProjectDTO")
+    @Mapping(source = "user.login", target = "login")
+    @Mapping(target = "status", ignore = true)
+    @Mapping(target = "project", ignore = true)
+    @Mapping(target = "createdBy", ignore = true)
+    @Mapping(target = "createdDate", ignore = true)
+    @Mapping(target = "lastModifiedBy", ignore = true)
+    @Mapping(target = "lastModifiedDate", ignore = true)
+    @Mapping(source = "user.roles", target = "roles")
+    SubjectDTO subjectToSubjectWithoutProjectDTO(Subject subject);
+
+    @IterableMapping(qualifiedByName = "subjectReducedProjectDTO")
+    List<SubjectDTO> subjectsToSubjectReducedProjectDTOs(List<Subject> subjects);
 
     @Mapping(source = "login", target = "user.login")
     @Mapping(target = "user.email", ignore = true)

--- a/src/main/java/org/radarcns/management/service/mapper/SubjectMapper.java
+++ b/src/main/java/org/radarcns/management/service/mapper/SubjectMapper.java
@@ -1,12 +1,14 @@
 package org.radarcns.management.service.mapper;
 
 import java.util.List;
+import javax.ws.rs.core.Context;
 import org.mapstruct.DecoratedWith;
 import org.mapstruct.IterableMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
 import org.mapstruct.Named;
+import org.radarcns.management.domain.Project;
 import org.radarcns.management.domain.Subject;
 import org.radarcns.management.service.dto.SubjectDTO;
 import org.radarcns.management.service.mapper.decorator.SubjectMapperDecorator;
@@ -65,8 +67,6 @@ public interface SubjectMapper {
     @Mapping(target = "removed", ignore = true)
     @Mapping(target = "metaTokens", ignore = true)
     Subject safeUpdateSubjectFromDTO(SubjectDTO subjectDto, @MappingTarget Subject subject);
-
-    List<Subject> subjectDTOsToSubjects(List<SubjectDTO> subjectDtos);
 
     /**
      * Generating the fromId for all mappers if the databaseType is sql, as the class has

--- a/src/main/java/org/radarcns/management/service/mapper/decorator/ProjectMapperDecorator.java
+++ b/src/main/java/org/radarcns/management/service/mapper/decorator/ProjectMapperDecorator.java
@@ -43,12 +43,12 @@ public abstract class ProjectMapperDecorator implements ProjectMapper {
         }
         ProjectDTO dto = delegate.projectToProjectDTOReduced(project);
         dto.setHumanReadableProjectName(project.getAttributes().get(HUMAN_READABLE_PROJECT_NAME));
+        dto.setSourceTypes(null);
         return dto;
     }
 
     @Override
     public Project projectDTOToProject(ProjectDTO projectDto) {
-
         if (projectDto == null) {
             return null;
         }
@@ -59,28 +59,6 @@ public abstract class ProjectMapperDecorator implements ProjectMapper {
             project.getAttributes().put(HUMAN_READABLE_PROJECT_NAME, projectName);
         }
         return project;
-    }
-
-    @Override
-    public List<ProjectDTO> projectsToProjectDTOs(List<Project> projects) {
-        if (projects == null) {
-            return null;
-        }
-
-        return projects.stream()
-                .map(this::projectToProjectDTO)
-                .collect(Collectors.toList());
-    }
-
-    @Override
-    public List<Project> projectDTOsToProjects(List<ProjectDTO> projectDtos) {
-        if (projectDtos == null) {
-            return null;
-        }
-
-        return projectDtos.stream()
-                .map(this::projectDTOToProject)
-                .collect(Collectors.toList());
     }
 
     @Override

--- a/src/main/java/org/radarcns/management/service/mapper/decorator/ProjectMapperDecorator.java
+++ b/src/main/java/org/radarcns/management/service/mapper/decorator/ProjectMapperDecorator.java
@@ -2,7 +2,6 @@ package org.radarcns.management.service.mapper.decorator;
 
 import static org.radarcns.management.service.dto.ProjectDTO.HUMAN_READABLE_PROJECT_NAME;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import java.util.stream.Collectors;
@@ -38,11 +37,11 @@ public abstract class ProjectMapperDecorator implements ProjectMapper {
 
 
     @Override
-    public ProjectDTO projectToProjectDTOWithoutSources(Project project) {
+    public ProjectDTO projectToProjectDTOReduced(Project project) {
         if (project == null) {
             return null;
         }
-        ProjectDTO dto = delegate.projectToProjectDTOWithoutSources(project);
+        ProjectDTO dto = delegate.projectToProjectDTOReduced(project);
         dto.setHumanReadableProjectName(project.getAttributes().get(HUMAN_READABLE_PROJECT_NAME));
         return dto;
     }

--- a/src/main/java/org/radarcns/management/service/mapper/decorator/ProjectMapperDecorator.java
+++ b/src/main/java/org/radarcns/management/service/mapper/decorator/ProjectMapperDecorator.java
@@ -5,6 +5,7 @@ import static org.radarcns.management.service.dto.ProjectDTO.HUMAN_READABLE_PROJ
 import java.util.ArrayList;
 import java.util.List;
 
+import java.util.stream.Collectors;
 import org.radarcns.management.domain.Project;
 import org.radarcns.management.repository.ProjectRepository;
 import org.radarcns.management.service.dto.MinimalProjectDetailsDTO;
@@ -35,6 +36,17 @@ public abstract class ProjectMapperDecorator implements ProjectMapper {
         return dto;
     }
 
+
+    @Override
+    public ProjectDTO projectToProjectDTOWithoutSources(Project project) {
+        if (project == null) {
+            return null;
+        }
+        ProjectDTO dto = delegate.projectToProjectDTOWithoutSources(project);
+        dto.setHumanReadableProjectName(project.getAttributes().get(HUMAN_READABLE_PROJECT_NAME));
+        return dto;
+    }
+
     @Override
     public Project projectDTOToProject(ProjectDTO projectDto) {
 
@@ -43,15 +55,9 @@ public abstract class ProjectMapperDecorator implements ProjectMapper {
         }
 
         Project project = delegate.projectDTOToProject(projectDto);
-        if (projectDto.getHumanReadableProjectName() != null && !projectDto
-                .getHumanReadableProjectName().isEmpty()) {
-            project.getAttributes().put(HUMAN_READABLE_PROJECT_NAME, projectDto
-                    .getHumanReadableProjectName());
-        }
-        if (projectDto.getHumanReadableProjectName() != null && !projectDto
-                .getHumanReadableProjectName().isEmpty()) {
-            project.getAttributes().put(HUMAN_READABLE_PROJECT_NAME, projectDto
-                    .getHumanReadableProjectName());
+        String projectName = projectDto.getHumanReadableProjectName();
+        if (projectName != null && !projectName.isEmpty()) {
+            project.getAttributes().put(HUMAN_READABLE_PROJECT_NAME, projectName);
         }
         return project;
     }
@@ -62,27 +68,20 @@ public abstract class ProjectMapperDecorator implements ProjectMapper {
             return null;
         }
 
-        List<ProjectDTO> list = new ArrayList<ProjectDTO>();
-        for (Project project : projects) {
-            list.add(this.projectToProjectDTO(project));
-        }
-
-        return list;
+        return projects.stream()
+                .map(this::projectToProjectDTO)
+                .collect(Collectors.toList());
     }
 
     @Override
     public List<Project> projectDTOsToProjects(List<ProjectDTO> projectDtos) {
-
         if (projectDtos == null) {
             return null;
         }
 
-        List<Project> list = new ArrayList<Project>();
-        for (ProjectDTO projectDto : projectDtos) {
-            list.add(this.projectDTOToProject(projectDto));
-        }
-
-        return list;
+        return projectDtos.stream()
+                .map(this::projectDTOToProject)
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/src/main/java/org/radarcns/management/service/mapper/decorator/ProjectMapperDecorator.java
+++ b/src/main/java/org/radarcns/management/service/mapper/decorator/ProjectMapperDecorator.java
@@ -2,9 +2,6 @@ package org.radarcns.management.service.mapper.decorator;
 
 import static org.radarcns.management.service.dto.ProjectDTO.HUMAN_READABLE_PROJECT_NAME;
 
-import java.util.List;
-
-import java.util.stream.Collectors;
 import org.radarcns.management.domain.Project;
 import org.radarcns.management.repository.ProjectRepository;
 import org.radarcns.management.service.dto.MinimalProjectDetailsDTO;

--- a/src/main/java/org/radarcns/management/service/mapper/decorator/SourceMapperDecorator.java
+++ b/src/main/java/org/radarcns/management/service/mapper/decorator/SourceMapperDecorator.java
@@ -1,5 +1,6 @@
 package org.radarcns.management.service.mapper.decorator;
 
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import org.radarcns.management.domain.Source;
 import org.radarcns.management.repository.SourceRepository;
@@ -47,8 +48,9 @@ public abstract class SourceMapperDecorator implements SourceMapper {
             if (sourceDto.getSubjectLogin() == null) {
                 source.setSubject(existingSource.getSubject());
             } else {
-                source.setSubject(subjectRepository.findOneWithEagerBySubjectLogin(sourceDto
-                        .getSubjectLogin()).get());
+                source.setSubject(subjectRepository
+                        .findOneWithEagerBySubjectLogin(sourceDto.getSubjectLogin())
+                        .orElseThrow(NoSuchElementException::new));
             }
         }
         return source;

--- a/src/main/java/org/radarcns/management/service/mapper/decorator/SubjectMapperDecorator.java
+++ b/src/main/java/org/radarcns/management/service/mapper/decorator/SubjectMapperDecorator.java
@@ -33,10 +33,10 @@ public abstract class SubjectMapperDecorator implements SubjectMapper {
 
     @Override
     public SubjectDTO subjectToSubjectDTO(Subject subject) {
-        SubjectDTO dto = subjectToSubjectWithoutProjectDTO(subject);
-        if (dto == null) {
+        if (subject == null) {
             return null;
         }
+        SubjectDTO dto = subjectToSubjectWithoutProjectDTO(subject);
         Project project = subject.getActiveProject()
                 .flatMap(p ->  projectRepository.findOneWithEagerRelationships(p.getId()))
                 .orElse(null);
@@ -49,10 +49,10 @@ public abstract class SubjectMapperDecorator implements SubjectMapper {
 
     @Override
     public SubjectDTO subjectToSubjectReducedProjectDTO(Subject subject) {
-        SubjectDTO dto = subjectToSubjectWithoutProjectDTO(subject);
-        if (dto == null) {
+        if (subject == null) {
             return null;
         }
+        SubjectDTO dto = subjectToSubjectWithoutProjectDTO(subject);
 
         subject.getActiveProject()
                 .ifPresent(project -> dto.setProject(

--- a/src/main/java/org/radarcns/management/service/mapper/decorator/SubjectMapperDecorator.java
+++ b/src/main/java/org/radarcns/management/service/mapper/decorator/SubjectMapperDecorator.java
@@ -1,8 +1,5 @@
 package org.radarcns.management.service.mapper.decorator;
 
-import java.util.List;
-
-import java.util.stream.Collectors;
 import org.mapstruct.MappingTarget;
 import org.radarcns.management.domain.Project;
 import org.radarcns.management.domain.Subject;
@@ -44,9 +41,11 @@ public abstract class SubjectMapperDecorator implements SubjectMapper {
                 .flatMap(p ->  projectRepository.findOneWithEagerRelationships(p.getId()))
                 .orElse(null);
         dto.setProject(projectMapper.projectToProjectDTO(project));
+
         return dto;
     }
 
+    @Override
     public SubjectDTO subjectToSubjectReducedProjectDTO(Subject subject) {
         SubjectDTO dto = subjectToSubjectWithoutProjectDTO(subject);
         if (dto == null) {
@@ -56,6 +55,12 @@ public abstract class SubjectMapperDecorator implements SubjectMapper {
         subject.getActiveProject()
                 .ifPresent(project -> dto.setProject(
                         projectMapper.projectToProjectDTOReduced(project)));
+
+        EntityAuditInfo auditInfo = revisionService.getAuditInfo(subject);
+        dto.setCreatedDate(auditInfo.getCreatedAt());
+        dto.setCreatedBy(auditInfo.getCreatedBy());
+        dto.setLastModifiedDate(auditInfo.getLastModifiedAt());
+        dto.setLastModifiedBy(auditInfo.getLastModifiedBy());
 
         return dto;
     }
@@ -67,12 +72,6 @@ public abstract class SubjectMapperDecorator implements SubjectMapper {
         }
         SubjectDTO dto = delegate.subjectToSubjectWithoutProjectDTO(subject);
         dto.setStatus(getSubjectStatus(subject));
-
-        EntityAuditInfo auditInfo = revisionService.getAuditInfo(subject);
-        dto.setCreatedDate(auditInfo.getCreatedAt());
-        dto.setCreatedBy(auditInfo.getCreatedBy());
-        dto.setLastModifiedDate(auditInfo.getLastModifiedAt());
-        dto.setLastModifiedBy(auditInfo.getLastModifiedBy());
 
         return dto;
     }

--- a/src/main/java/org/radarcns/management/service/mapper/decorator/SubjectMapperDecorator.java
+++ b/src/main/java/org/radarcns/management/service/mapper/decorator/SubjectMapperDecorator.java
@@ -31,14 +31,26 @@ public abstract class SubjectMapperDecorator implements SubjectMapper {
 
     @Override
     public SubjectDTO subjectToSubjectDTO(Subject subject) {
+        SubjectDTO dto = subjectToSubjectDTOWithoutProject(subject);
+        if (dto == null) {
+            return null;
+        }
+
+        subject.getActiveProject()
+                .ifPresent(project -> dto.setProject(
+                        projectMapper.projectToProjectDTOWithoutSources(project)));
+
+        return dto;
+    }
+
+
+    @Override
+    public SubjectDTO subjectToSubjectDTOWithoutProject(Subject subject) {
         if (subject == null) {
             return null;
         }
-        SubjectDTO dto = delegate.subjectToSubjectDTO(subject);
+        SubjectDTO dto = delegate.subjectToSubjectDTOWithoutProject(subject);
         dto.setStatus(getSubjectStatus(subject));
-        subject.getActiveProject()
-                .ifPresent(
-                    project -> dto.setProject(projectMapper.projectToProjectDTO(project)));
 
         EntityAuditInfo auditInfo = revisionService.getAuditInfo(subject);
         dto.setCreatedDate(auditInfo.getCreatedAt());

--- a/src/main/java/org/radarcns/management/service/mapper/decorator/SubjectMapperDecorator.java
+++ b/src/main/java/org/radarcns/management/service/mapper/decorator/SubjectMapperDecorator.java
@@ -42,6 +42,8 @@ public abstract class SubjectMapperDecorator implements SubjectMapper {
                 .orElse(null);
         dto.setProject(projectMapper.projectToProjectDTO(project));
 
+        addAuditInfo(subject, dto);
+
         return dto;
     }
 
@@ -56,13 +58,17 @@ public abstract class SubjectMapperDecorator implements SubjectMapper {
                 .ifPresent(project -> dto.setProject(
                         projectMapper.projectToProjectDTOReduced(project)));
 
+        addAuditInfo(subject, dto);
+
+        return dto;
+    }
+
+    private void addAuditInfo(Subject subject, SubjectDTO dto) {
         EntityAuditInfo auditInfo = revisionService.getAuditInfo(subject);
         dto.setCreatedDate(auditInfo.getCreatedAt());
         dto.setCreatedBy(auditInfo.getCreatedBy());
         dto.setLastModifiedDate(auditInfo.getLastModifiedAt());
         dto.setLastModifiedBy(auditInfo.getLastModifiedBy());
-
-        return dto;
     }
 
     @Override

--- a/src/main/java/org/radarcns/management/web/rest/OAuthClientsResource.java
+++ b/src/main/java/org/radarcns/management/web/rest/OAuthClientsResource.java
@@ -29,9 +29,7 @@ import org.radarcns.management.service.SubjectService;
 import org.radarcns.management.service.UserService;
 import org.radarcns.management.service.dto.ClientDetailsDTO;
 import org.radarcns.management.service.dto.ClientPairInfoDTO;
-import org.radarcns.management.service.dto.SubjectDTO;
 import org.radarcns.management.service.mapper.ClientDetailsMapper;
-import org.radarcns.management.service.mapper.SubjectMapper;
 import org.radarcns.management.web.rest.util.HeaderUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -70,9 +68,6 @@ public class OAuthClientsResource {
 
     @Autowired
     private SubjectService subjectService;
-
-    @Autowired
-    private SubjectMapper subjectMapper;
 
     @Autowired
     private UserService userService;

--- a/src/main/java/org/radarcns/management/web/rest/OAuthClientsResource.java
+++ b/src/main/java/org/radarcns/management/web/rest/OAuthClientsResource.java
@@ -20,6 +20,7 @@ import javax.validation.Valid;
 import com.codahale.metrics.annotation.Timed;
 import org.radarcns.auth.config.Constants;
 import org.radarcns.auth.exception.NotAuthorizedException;
+import org.radarcns.management.domain.Project;
 import org.radarcns.management.domain.Subject;
 import org.radarcns.management.domain.User;
 import org.radarcns.management.service.OAuthClientService;
@@ -202,11 +203,12 @@ public class OAuthClientsResource {
 
         // lookup the subject
         Subject subject = subjectService.findOneByLogin(login);
-        SubjectDTO subjectDto = subjectMapper.subjectToSubjectDTO(subject);
+        String project = subject.getActiveProject()
+                .map(Project::getProjectName)
+                .orElse(null);
 
         // Users who can update a subject can also generate a refresh token for that subject
-        checkPermissionOnSubject(getJWT(servletRequest), SUBJECT_UPDATE,
-                subjectDto.getProject().getProjectName(), subjectDto.getLogin());
+        checkPermissionOnSubject(getJWT(servletRequest), SUBJECT_UPDATE, project, login);
 
         ClientPairInfoDTO cpi = oAuthClientService.createRefreshToken(subject, clientId);
         // generate audit event

--- a/src/main/java/org/radarcns/management/web/rest/ProjectResource.java
+++ b/src/main/java/org/radarcns/management/web/rest/ProjectResource.java
@@ -303,11 +303,11 @@ public class ProjectResource {
         if (includeInactiveParticipants) {
             page = subjectRepository.findAllByProjectNameAndAuthoritiesIn(pageable, projectName,
                     Arrays.asList(PARTICIPANT, INACTIVE_PARTICIPANT))
-                    .map(subjectMapper::subjectToSubjectDTO);
+                    .map(subjectMapper::subjectToSubjectDTOWithoutProject);
         } else {
             page = subjectRepository.findAllByProjectNameAndAuthoritiesIn(pageable, projectName,
                     Collections.singletonList(PARTICIPANT))
-                    .map(subjectMapper::subjectToSubjectDTO);
+                    .map(subjectMapper::subjectToSubjectDTOWithoutProject);
         }
 
         HttpHeaders headers = PaginationUtil

--- a/src/main/java/org/radarcns/management/web/rest/ProjectResource.java
+++ b/src/main/java/org/radarcns/management/web/rest/ProjectResource.java
@@ -303,11 +303,11 @@ public class ProjectResource {
         if (includeInactiveParticipants) {
             page = subjectRepository.findAllByProjectNameAndAuthoritiesIn(pageable, projectName,
                     Arrays.asList(PARTICIPANT, INACTIVE_PARTICIPANT))
-                    .map(subjectMapper::subjectToSubjectDTOWithoutProject);
+                    .map(subjectMapper::subjectToSubjectWithoutProjectDTO);
         } else {
             page = subjectRepository.findAllByProjectNameAndAuthoritiesIn(pageable, projectName,
                     Collections.singletonList(PARTICIPANT))
-                    .map(subjectMapper::subjectToSubjectDTOWithoutProject);
+                    .map(subjectMapper::subjectToSubjectWithoutProjectDTO);
         }
 
         HttpHeaders headers = PaginationUtil

--- a/src/main/java/org/radarcns/management/web/rest/SubjectResource.java
+++ b/src/main/java/org/radarcns/management/web/rest/SubjectResource.java
@@ -50,6 +50,7 @@ import org.radarcns.management.service.SourceService;
 import org.radarcns.management.service.SourceTypeService;
 import org.radarcns.management.service.SubjectService;
 import org.radarcns.management.service.dto.MinimalSourceDetailsDTO;
+import org.radarcns.management.service.dto.ProjectDTO;
 import org.radarcns.management.service.dto.RevisionDTO;
 import org.radarcns.management.service.dto.SubjectDTO;
 import org.radarcns.management.service.mapper.SubjectMapper;
@@ -264,17 +265,18 @@ public class SubjectResource {
             if (!subject.isPresent()) {
                 return ResponseEntity.notFound().build();
             }
-            SubjectDTO subjectDto = subjectMapper.subjectToSubjectDTO(subject.get());
+            SubjectDTO subjectDto = subjectMapper.subjectToSubjectReducedProjectDTO(subject.get());
             return ResponseEntity.ok(Collections.singletonList(subjectDto));
         } else if (projectName == null && externalId != null) {
             List<Subject> subjects = subjectRepository
                     .findAllByExternalIdAndAuthoritiesIn(externalId, authoritiesToInclude);
-            return ResponseUtil
-                    .wrapOrNotFound(Optional.of(subjectMapper.subjectsToSubjectDTOs(subjects)));
+            return ResponseUtil.wrapOrNotFound(Optional.of(
+                    subjectMapper.subjectsToSubjectReducedProjectDTOs(subjects)));
         } else if (projectName != null) {
             Page<SubjectDTO> page = subjectRepository
                     .findAllByProjectNameAndAuthoritiesIn(pageable, projectName,
-                            authoritiesToInclude).map(subjectMapper::subjectToSubjectDTO);
+                            authoritiesToInclude)
+                    .map(subjectMapper::subjectToSubjectWithoutProjectDTO);
 
             HttpHeaders headers = PaginationUtil
                     .generatePaginationHttpHeaders(page, "/api/subjects");
@@ -301,9 +303,16 @@ public class SubjectResource {
         log.debug("REST request to get Subject : {}", login);
         Subject subject = subjectService.findOneByLogin(login);
         SubjectDTO subjectDto = subjectMapper.subjectToSubjectDTO(subject);
-        checkPermissionOnSubject(getJWT(servletRequest), SUBJECT_READ, subjectDto.getProject()
-                .getProjectName(), subjectDto.getLogin());
-        return ResponseUtil.wrapOrNotFound(Optional.ofNullable(subjectDto));
+        if (subjectDto == null) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        } else {
+            ProjectDTO project = subjectDto.getProject();
+            String projectName = project == null ? null : project.getProjectName();
+
+            checkPermissionOnSubject(getJWT(servletRequest), SUBJECT_READ, projectName,
+                    subjectDto.getLogin());
+            return ResponseEntity.ok(subjectDto);
+        }
     }
 
     /**
@@ -332,12 +341,15 @@ public class SubjectResource {
         // This stream returns true if all values are equal to blank. To prevent people with no
         // access to the requested subject in any of the subject history's projects from gaining
         // information on the subject history this way, we throw a NotAuthorized.
-        if (page.getContent().stream().map(blank::equals)
-                    .reduce(Boolean.TRUE, Boolean::logicalAnd)) {
+        if (page.getContent().stream()
+                .map(RevisionDTO::getEntity)
+                .allMatch(blank::equals)) {
             throw new NotAuthorizedException();
         }
-        return ResponseEntity.ok().headers(PaginationUtil.generatePaginationHttpHeaders(page,
-                HeaderUtil.buildPath("subjects", login, "revisions"))).body(page.getContent());
+        return ResponseEntity.ok()
+                .headers(PaginationUtil.generatePaginationHttpHeaders(page,
+                        HeaderUtil.buildPath("subjects", login, "revisions")))
+                .body(page.getContent());
     }
 
     /**
@@ -373,9 +385,8 @@ public class SubjectResource {
         log.debug("REST request to delete Subject : {}", login);
         Subject subject = subjectService.findOneByLogin(login);
 
-        SubjectDTO subjectDto = subjectMapper.subjectToSubjectDTO(subject);
-        checkPermissionOnSubject(getJWT(servletRequest), SUBJECT_DELETE, subjectDto.getProject()
-                .getProjectName(), subjectDto.getLogin());
+        String projectName = subject.getActiveProject().map(Project::getProjectName).orElse(null);
+        checkPermissionOnSubject(getJWT(servletRequest), SUBJECT_DELETE, projectName, login);
         subjectService.deleteSubject(login);
         return ResponseEntity.ok()
                 .headers(HeaderUtil.createEntityDeletionAlert(SUBJECT, login)).build();
@@ -490,23 +501,26 @@ public class SubjectResource {
         boolean withInactiveSources = withInactiveSourcesParam == null ? false
                 : withInactiveSourcesParam;
         // check the subject id
-        Optional<Subject> subject = subjectRepository.findOneWithEagerBySubjectLogin(login);
-        if (!subject.isPresent()) {
+        Optional<Subject> subjectOptional = subjectRepository.findOneWithEagerBySubjectLogin(login);
+        if (!subjectOptional.isPresent()) {
             return ResponseEntity.notFound().build();
         }
 
-        SubjectDTO subjectDto = subjectMapper.subjectToSubjectDTO(subject.get());
-        checkPermissionOnSubject(getJWT(servletRequest), SUBJECT_READ, subjectDto.getProject()
-                .getProjectName(), subjectDto.getLogin());
+        Subject subject = subjectOptional.get();
+
+        String projectName = subject.getActiveProject()
+                .map(Project::getProjectName)
+                .orElse(null);
+
+        checkPermissionOnSubject(getJWT(servletRequest), SUBJECT_READ, projectName, login);
 
         if (withInactiveSources) {
-            return ResponseEntity.ok()
-                    .body(subjectService.findSubjectSourcesFromRevisions(subject.get()));
+            return ResponseEntity.ok(subjectService.findSubjectSourcesFromRevisions(subject));
+        } else {
+            log.debug("REST request to get sources of Subject : {}", login);
+
+            return ResponseEntity.ok(subjectService.getSources(subject));
         }
-
-        log.debug("REST request to get sources of Subject : {}", login);
-
-        return ResponseEntity.ok().body(subjectService.getSources(subject.get()));
     }
 
 
@@ -538,18 +552,21 @@ public class SubjectResource {
             throws NotFoundException, NotAuthorizedException,
             URISyntaxException {
         // check the subject id
-        Optional<Subject> subject = subjectRepository.findOneWithEagerBySubjectLogin(login);
-        if (!subject.isPresent()) {
+        Optional<Subject> subjectOptional = subjectRepository.findOneWithEagerBySubjectLogin(login);
+        if (!subjectOptional.isPresent()) {
             throw new NotFoundException("Subject ID not found", SUBJECT, ErrorConstants
                 .ERR_SUBJECT_NOT_FOUND, Collections.singletonMap("subjectLogin", login));
         }
         // check the permission to update source
-        SubjectDTO subjectDto = subjectMapper.subjectToSubjectDTO(subject.get());
-        checkPermissionOnSubject(getJWT(servletRequest), SUBJECT_UPDATE,
-                subjectDto.getProject().getProjectName(), subjectDto.getLogin());
+        Subject subject = subjectOptional.get();
+
+        String projectName = subject.getActiveProject()
+                .map(Project::getProjectName)
+                .orElse(null);
+        checkPermissionOnSubject(getJWT(servletRequest), SUBJECT_UPDATE, projectName, login);
 
         // find source under subject
-        List<Source> sources = subject.get().getSources().stream()
+        List<Source> sources = subject.getSources().stream()
                 .filter(s -> s.getSourceName().equals(sourceName))
                 .collect(Collectors.toList());
 
@@ -563,7 +580,7 @@ public class SubjectResource {
         }
 
         // there should be only one source under a source-name.
-        return ResponseEntity.ok().body(sourceService.safeUpdateOfAttributes(sources.get(0),
-                attributes));
+        return ResponseEntity.ok(
+                sourceService.safeUpdateOfAttributes(sources.get(0), attributes));
     }
 }

--- a/src/test/java/org/radarcns/management/web/rest/OAuthClientsResourceIntTest.java
+++ b/src/test/java/org/radarcns/management/web/rest/OAuthClientsResourceIntTest.java
@@ -18,6 +18,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.MockitoAnnotations;
+import org.radarcns.auth.authentication.OAuthHelper;
 import org.radarcns.management.ManagementPortalApp;
 import org.radarcns.management.security.JwtAuthenticationFilter;
 import org.radarcns.management.service.OAuthClientService;
@@ -25,9 +26,7 @@ import org.radarcns.management.service.SubjectService;
 import org.radarcns.management.service.UserService;
 import org.radarcns.management.service.dto.ClientDetailsDTO;
 import org.radarcns.management.service.mapper.ClientDetailsMapper;
-import org.radarcns.management.service.mapper.SubjectMapper;
 import org.radarcns.management.web.rest.errors.ExceptionTranslator;
-import org.radarcns.auth.authentication.OAuthHelper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
@@ -60,9 +59,6 @@ public class OAuthClientsResourceIntTest {
 
     @Autowired
     private SubjectService subjectService;
-
-    @Autowired
-    private SubjectMapper subjectMapper;
 
     @Autowired
     private UserService userService;
@@ -98,8 +94,6 @@ public class OAuthClientsResourceIntTest {
                 clientDetailsMapper);
         ReflectionTestUtils.setField(oauthClientsResource, "subjectService",
                 subjectService);
-        ReflectionTestUtils.setField(oauthClientsResource, "subjectMapper",
-                subjectMapper);
         ReflectionTestUtils.setField(oauthClientsResource, "userService",
                 userService);
         ReflectionTestUtils.setField(oauthClientsResource, "servletRequest",
@@ -160,7 +154,7 @@ public class OAuthClientsResourceIntTest {
                 details.getResourceIds());
         assertThat(testDetails.getAuthorizedGrantTypes()).containsExactlyElementsOf(
                 details.getAuthorizedGrantTypes());
-        details.getAutoApproveScopes().stream().forEach(scope ->
+        details.getAutoApproveScopes().forEach(scope ->
                 assertThat(testDetails.isAutoApprove(scope)).isTrue());
         assertThat(testDetails.getAccessTokenValiditySeconds()).isEqualTo(
                 details.getAccessTokenValiditySeconds().intValue());


### PR DESCRIPTION
Aims to fix #443.

Changes:
- If a source type is returned, its encapsulated `sourceData[].sourceType` is not returned.
- If a project is returned or users are listed as part of a project, project information is not returned
- If a project is returned as part of a user or subject, the project does not list source types. The only exception is a single subject request: here the source types are returned.
- Do not convert a subject to a DTO just for auth checking.