### PR TITLE
Allow services to get more claims information

### DIFF
--- a/radar-auth/src/main/java/org/radarcns/auth/token/RadarToken.java
+++ b/radar-auth/src/main/java/org/radarcns/auth/token/RadarToken.java
@@ -85,6 +85,26 @@ public interface RadarToken {
     String getType();
 
     /**
+     * Client that the token is associated to.
+     * @return client ID if set or null if unknown.
+     */
+    String getClientId();
+
+    /**
+     * Get a token claim by name.
+     * @param name claim name.
+     * @return a claim value or null if none was found or the type was not a string.
+     */
+    String getClaimString(String name);
+
+    /**
+     * Get a token claim list by name.
+     * @param name claim name.
+     * @return a claim list of values or null if none was found or the type was not a string.
+     */
+    List<String> getClaimList(String name);
+
+    /**
      * Check if this token gives the given permission, not taking into account project affiliations.
      *
      * <p>This token <strong>must</strong> have the permission in its set of scopes. If it's a

--- a/radar-auth/src/test/java/org/radarcns/auth/token/AbstractRadarTokenTest.java
+++ b/radar-auth/src/test/java/org/radarcns/auth/token/AbstractRadarTokenTest.java
@@ -83,6 +83,21 @@ public class AbstractRadarTokenTest {
         public String getType() {
             return null;
         }
+
+        @Override
+        public String getClientId() {
+            return null;
+        }
+
+        @Override
+        public String getClaimString(String name) {
+            return null;
+        }
+
+        @Override
+        public List<String> getClaimList(String name) {
+            return null;
+        }
     }
 
     @Test


### PR DESCRIPTION
This way other parts of the JWT can also be exposed by services. For example, the client ID.