### PR TITLE
Improve dependency injection and use correct OAuth token key endpoint

### DIFF
--- a/src/main/java/org/radarcns/management/config/OAuth2ServerConfiguration.java
+++ b/src/main/java/org/radarcns/management/config/OAuth2ServerConfiguration.java
@@ -180,7 +180,7 @@ public class OAuth2ServerConfiguration {
         private JdbcClientDetailsService jdbcClientDetailsService;
 
         @Autowired
-        private ManagementPortalProperties managementPortalProperties;
+        private ManagementPortalOauthKeyStoreHandler keyStoreHandler;
 
         @Bean
         protected AuthorizationCodeServices authorizationCodeServices() {
@@ -210,10 +210,8 @@ public class OAuth2ServerConfiguration {
         @Bean
         public ManagementPortalJwtAccessTokenConverter accessTokenConverter() {
             logger.debug("loading token converter from keystore configurations");
-            ManagementPortalOauthKeyStoreHandler keyFactory =
-                    ManagementPortalOauthKeyStoreHandler.build(managementPortalProperties);
-            return new ManagementPortalJwtAccessTokenConverter(keyFactory.getAlgorithmForSigning(),
-                    keyFactory.getVerifiers());
+            return new ManagementPortalJwtAccessTokenConverter(keyStoreHandler.getAlgorithmForSigning(),
+                    keyStoreHandler.getVerifiers());
         }
 
         @Bean

--- a/src/main/java/org/radarcns/management/config/OAuth2ServerConfiguration.java
+++ b/src/main/java/org/radarcns/management/config/OAuth2ServerConfiguration.java
@@ -210,7 +210,8 @@ public class OAuth2ServerConfiguration {
         @Bean
         public ManagementPortalJwtAccessTokenConverter accessTokenConverter() {
             logger.debug("loading token converter from keystore configurations");
-            return new ManagementPortalJwtAccessTokenConverter(keyStoreHandler.getAlgorithmForSigning(),
+            return new ManagementPortalJwtAccessTokenConverter(
+                    keyStoreHandler.getAlgorithmForSigning(),
                     keyStoreHandler.getVerifiers());
         }
 

--- a/src/main/java/org/radarcns/management/config/SecurityConfiguration.java
+++ b/src/main/java/org/radarcns/management/config/SecurityConfiguration.java
@@ -44,7 +44,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
     private ApplicationEventPublisher applicationEventPublisher;
 
     @Autowired
-    private ManagementPortalProperties managementPortalProperties;
+    private ManagementPortalOauthKeyStoreHandler keyStoreHandler;
 
     @PostConstruct
     public void init() {
@@ -144,8 +144,6 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
      * @return the JwtAuthenticationFilter
      */
     public Filter jwtAuthenticationFilter() {
-        ManagementPortalOauthKeyStoreHandler keyStoreKeyFactory =
-                ManagementPortalOauthKeyStoreHandler.build(managementPortalProperties);
-        return new JwtAuthenticationFilter(keyStoreKeyFactory.getTokenValidator());
+        return new JwtAuthenticationFilter(keyStoreHandler.getTokenValidator());
     }
 }

--- a/src/main/java/org/radarcns/management/security/jwt/ManagementPortalOauthKeyStoreHandler.java
+++ b/src/main/java/org/radarcns/management/security/jwt/ManagementPortalOauthKeyStoreHandler.java
@@ -110,7 +110,7 @@ public class ManagementPortalOauthKeyStoreHandler {
         }
 
         this.managementPortalBaseUrl = "http://localhost:"
-                + environment.getProperty("local.server.port")
+                + environment.getProperty("server.port")
                 + servletContext.getContextPath();
         logger.info("Using Management Portal base-url {}", this.managementPortalBaseUrl);
 

--- a/src/main/java/org/radarcns/management/web/rest/TokenKeyEndpoint.java
+++ b/src/main/java/org/radarcns/management/web/rest/TokenKeyEndpoint.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class TokenKeyEndpoint {
     private static final Logger logger = LoggerFactory.getLogger(TokenKeyEndpoint.class);
 
-    private ManagementPortalOauthKeyStoreHandler keyStoreHandler;
+    private final ManagementPortalOauthKeyStoreHandler keyStoreHandler;
 
     @Autowired
     public TokenKeyEndpoint(

--- a/src/main/java/org/radarcns/management/web/rest/TokenKeyEndpoint.java
+++ b/src/main/java/org/radarcns/management/web/rest/TokenKeyEndpoint.java
@@ -1,10 +1,7 @@
 package org.radarcns.management.web.rest;
 
-import javax.annotation.PostConstruct;
-
 import com.codahale.metrics.annotation.Timed;
 import org.radarcns.auth.security.jwk.JavaWebKeySet;
-import org.radarcns.management.config.ManagementPortalProperties;
 import org.radarcns.management.security.jwt.ManagementPortalOauthKeyStoreHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -14,18 +11,15 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class TokenKeyEndpoint {
-
     private static final Logger logger = LoggerFactory.getLogger(TokenKeyEndpoint.class);
 
+    private ManagementPortalOauthKeyStoreHandler keyStoreHandler;
+
     @Autowired
-    private ManagementPortalProperties managementPortalProperties;
-
-    private ManagementPortalOauthKeyStoreHandler managementPortalOauthKeyStoreHandler;
-
-    @PostConstruct
-    public void init() {
-        this.managementPortalOauthKeyStoreHandler =
-                ManagementPortalOauthKeyStoreHandler.build(managementPortalProperties);
+    public TokenKeyEndpoint(
+            ManagementPortalOauthKeyStoreHandler keyStoreHandler
+    ) {
+        this.keyStoreHandler = keyStoreHandler;
     }
 
     /**
@@ -38,7 +32,6 @@ public class TokenKeyEndpoint {
     @Timed
     public JavaWebKeySet getKey() {
         logger.debug("Requesting verifier public keys...");
-        return managementPortalOauthKeyStoreHandler.loadJwks();
+        return keyStoreHandler.loadJwks();
     }
-
 }


### PR DESCRIPTION
Dependency injection is now used for ManagementPortalOauthKeyStoreHandler. This allows it to get the local URL of the oauth path. It also simplifies the logic in other components for getting access to this handler.