### PR TITLE
Fix warning with Node 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM openjdk:8-jdk as builder
 
 # install node
-RUN curl -sL https://deb.nodesource.com/setup_11.x | bash - && \
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
     apt-get install -yq nodejs build-essential && \
     npm install -g npm yarn
 


### PR DESCRIPTION
Complains that node 11 is no longer supported.