### PR TITLE
Ensure that refresh tokens from other resources can be read

### DIFF
--- a/src/main/java/org/radarcns/management/config/OAuth2ServerConfiguration.java
+++ b/src/main/java/org/radarcns/management/config/OAuth2ServerConfiguration.java
@@ -212,7 +212,8 @@ public class OAuth2ServerConfiguration {
             logger.debug("loading token converter from keystore configurations");
             return new ManagementPortalJwtAccessTokenConverter(
                     keyStoreHandler.getAlgorithmForSigning(),
-                    keyStoreHandler.getVerifiers());
+                    keyStoreHandler.getVerifiers(),
+                    keyStoreHandler.getRefreshTokenVerifiers());
         }
 
         @Bean

--- a/src/main/java/org/radarcns/management/security/jwt/ManagementPortalJwtTokenStore.java
+++ b/src/main/java/org/radarcns/management/security/jwt/ManagementPortalJwtTokenStore.java
@@ -99,7 +99,6 @@ public class ManagementPortalJwtTokenStore implements TokenStore {
         OAuth2AccessToken accessToken = convertAccessToken(tokenValue);
 
         if (jwtAccessTokenConverter.isRefreshToken(accessToken)) {
-
             throw new InvalidTokenException("Encoded token is a refresh token");
         }
         return accessToken;

--- a/src/main/java/org/radarcns/management/security/jwt/ManagementPortalOauthKeyStoreHandler.java
+++ b/src/main/java/org/radarcns/management/security/jwt/ManagementPortalOauthKeyStoreHandler.java
@@ -116,7 +116,9 @@ public class ManagementPortalOauthKeyStoreHandler {
                 + servletContext.getContextPath();
         logger.info("Using Management Portal base-url {}", this.managementPortalBaseUrl);
 
-        List<Algorithm> algorithms = Stream.concat(loadAlgorithmsFromAlias(), loadDeprecatedAlgorithms())
+        List<Algorithm> algorithms = Stream.concat(
+                loadAlgorithmsFromAlias(),
+                loadDeprecatedAlgorithms())
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList());
 

--- a/src/main/java/org/radarcns/management/security/jwt/ManagementPortalOauthKeyStoreHandler.java
+++ b/src/main/java/org/radarcns/management/security/jwt/ManagementPortalOauthKeyStoreHandler.java
@@ -2,6 +2,7 @@ package org.radarcns.management.security.jwt;
 
 import static org.radarcns.management.security.jwt.ManagementPortalJwtAccessTokenConverter.RES_MANAGEMENT_PORTAL;
 
+import com.auth0.jwt.JWT;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -79,6 +80,7 @@ public class ManagementPortalOauthKeyStoreHandler {
     private final TokenValidatorConfig deprecatedValidatedConfig;
 
     private final List<JWTVerifier> verifiers;
+    private final List<JWTVerifier> refreshTokenVerifiers;
 
     private final AlgorithmLoader algorithmLoader = new AlgorithmLoader();
 
@@ -114,7 +116,17 @@ public class ManagementPortalOauthKeyStoreHandler {
                 + servletContext.getContextPath();
         logger.info("Using Management Portal base-url {}", this.managementPortalBaseUrl);
 
-        verifiers = Stream.concat(loadVerifiersFromAlias(), loadDeprecatedVerifiers())
+        List<Algorithm> algorithms = Stream.concat(loadAlgorithmsFromAlias(), loadDeprecatedAlgorithms())
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+
+        verifiers = algorithms.stream()
+                .map(algo -> JWT.require(algo).withAudience(RES_MANAGEMENT_PORTAL).build())
+                .collect(Collectors.toList());
+        // No need to check audience with a refresh token: it can be used
+        // to refresh tokens intended for other resources.
+        refreshTokenVerifiers = algorithms.stream()
+                .map(algo -> JWT.require(algo).build())
                 .collect(Collectors.toList());
     }
 
@@ -123,16 +135,14 @@ public class ManagementPortalOauthKeyStoreHandler {
      * @return deprecated verifiers in a stream.
      */
     @SuppressWarnings("deprecation")
-    private Stream<JWTVerifier> loadDeprecatedVerifiers() {
+    private Stream<Algorithm> loadDeprecatedAlgorithms() {
         if (deprecatedValidatedConfig == null) {
             return Stream.empty();
         }
 
         return deprecatedValidatedConfig.getPublicKeys()
                 .stream()
-                .map(algorithmLoader::loadDeprecatedAlgorithmFromPublicKey)
-                .filter(Objects::nonNull)
-                .map(algo -> AlgorithmLoader.buildVerifier(algo, RES_MANAGEMENT_PORTAL));
+                .map(algorithmLoader::loadDeprecatedAlgorithmFromPublicKey);
     }
 
     private static void checkOAuthConfig(ManagementPortalProperties managementPortalProperties) {
@@ -207,14 +217,12 @@ public class ManagementPortalOauthKeyStoreHandler {
     /**
      * Load default verifiers from configured keystore and aliases.
      */
-    private Stream<JWTVerifier> loadVerifiersFromAlias() {
+    private Stream<Algorithm> loadAlgorithmsFromAlias() {
         return this.verifierPublicKeyAliasList.stream()
                 .map(this::getKeyPair)
                 .map(ManagementPortalOauthKeyStoreHandler::getJwtAlgorithm)
                 .filter(Objects::nonNull)
-                .map(JwtAlgorithm::getAlgorithm)
-                .filter(Objects::nonNull)
-                .map(algo -> AlgorithmLoader.buildVerifier(algo, RES_MANAGEMENT_PORTAL));
+                .map(JwtAlgorithm::getAlgorithm);
     }
 
     public List<JWTVerifier> getVerifiers() {
@@ -362,5 +370,9 @@ public class ManagementPortalOauthKeyStoreHandler {
                         : Collections.emptyList();
             }
         };
+    }
+
+    public List<JWTVerifier> getRefreshTokenVerifiers() {
+        return refreshTokenVerifiers;
     }
 }


### PR DESCRIPTION
Issue:
An OAuth client with audience other than `res_ManagementPortal` could not refresh its token. This occurs for example in frontend clients for a dedicated backend.

Cause:
JWTVerifiers, including those for refresh tokens, required that the audience of a JWT was `res_ManagementPortal`. This disabled the `refresh_token` OAuth 2.0 flow for clients that do not have `res_ManagementPortal` as an audience.

Fix:
First check whether a token is a refresh token. If so, don't check the audience. If it is an access token, the audience is still required to be `res_ManagementPortal`.