### PR TITLE
Avoid exposing valid tokens in logs

### DIFF
--- a/radar-auth/src/main/java/org/radarcns/auth/authentication/TokenValidator.java
+++ b/radar-auth/src/main/java/org/radarcns/auth/authentication/TokenValidator.java
@@ -139,7 +139,8 @@ public class TokenValidator {
 
                 Map<String, Claim> claims = jwt.getClaims();
 
-                LOGGER.debug("JWT claims from token {} are {}", token, claims);
+                // Do not print full token with signature to avoid exposing valid token in logs.
+                LOGGER.debug("Verified JWT header {} and payload {}", jwt.getHeader(), jwt.getPayload());
 
                 // check for scope claim
                 if (!claims.containsKey(JwtRadarToken.SCOPE_CLAIM)) {


### PR DESCRIPTION
Removes a log statement that logs a full token. This would allow someone with access to the logs to get access to the system as any authorised user. Also, since the claims have no toString implemented, printing the claims yields no useful information.

The header and payload can still be used for debugging purposes. Since the signature is not exposed, they cannot be used as an authentication mechanism.