### PR TITLE
Fix/pagination history

### DIFF
--- a/src/main/webapp/app/admin/admin.module.ts
+++ b/src/main/webapp/app/admin/admin.module.ts
@@ -2,6 +2,7 @@ import { CUSTOM_ELEMENTS_SCHEMA, NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 
 import { ManagementPortalSharedModule } from '../shared';
+import { ResolvePagingParams } from '../shared/commons';
 
 import {
     adminState,
@@ -26,7 +27,6 @@ import {
     UserMgmtDialogComponent,
     UserModalService,
     UserResolve,
-    UserResolvePagingParams,
     UserSendActivationLinkComponent,
     UserSendActivationLinkDialogComponent,
 } from './';
@@ -69,7 +69,7 @@ import { RoleComponent } from './user-management/role.component';
         JhiHealthService,
         JhiMetricsService,
         LogsService,
-        UserResolvePagingParams,
+        ResolvePagingParams,
         UserResolve,
         UserModalService,
     ],

--- a/src/main/webapp/app/admin/user-management/role.component.ts
+++ b/src/main/webapp/app/admin/user-management/role.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { AlertService, EventManager, JhiLanguageService } from 'ng-jhipster';
 import { Subscription } from 'rxjs/Subscription';
-import { AuthorityService, Principal, Project, ProjectService } from '../../shared';
+import { AuthorityService, Project, ProjectService } from '../../shared';
 
 import { Role } from './role.model';
 import {HttpResponse} from '@angular/common/http';
@@ -12,7 +12,6 @@ import {HttpResponse} from '@angular/common/http';
 })
 export class RoleComponent implements OnInit {
     @Input() roles: Role[];
-    currentAccount: any;
     eventSubscriber: Subscription;
     authorities: string[];
     projects: Project[];
@@ -24,8 +23,8 @@ export class RoleComponent implements OnInit {
                 private authorityService: AuthorityService,
                 private projectService: ProjectService,
                 private alertService: AlertService,
-                private eventManager: EventManager,
-                private principal: Principal) {
+                private eventManager: EventManager
+    ) {
         this.jhiLanguageService.addLocation('role');
     }
 
@@ -38,9 +37,6 @@ export class RoleComponent implements OnInit {
         });
         this.projectService.query().subscribe((res: HttpResponse<any>) => {
             this.projects = res.body;
-        });
-        this.principal.identity().then((account) => {
-            this.currentAccount = account;
         });
     }
 

--- a/src/main/webapp/app/admin/user-management/user-management.route.ts
+++ b/src/main/webapp/app/admin/user-management/user-management.route.ts
@@ -17,6 +17,7 @@ import { UserDialogComponent } from './user-management-dialog.component';
 import { UserMgmtComponent } from './user-management.component';
 import { UserSendActivationLinkComponent } from './user-mgnt-send-activation.component';
 import { SYSTEM_ADMIN} from '../../shared/constants/common.constants';
+import { ResolvePagingParams } from '../../shared/commons';
 
 @Injectable()
 export class UserResolve implements CanActivate {
@@ -30,29 +31,12 @@ export class UserResolve implements CanActivate {
     }
 }
 
-@Injectable()
-export class UserResolvePagingParams implements Resolve<any> {
-
-    constructor(private paginationUtil: PaginationUtil) {
-    }
-
-    resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
-        const page = route.queryParams['page'] ? route.queryParams['page'] : '1';
-        const sort = route.queryParams['sort'] ? route.queryParams['sort'] : 'id,asc';
-        return {
-            page: this.paginationUtil.parsePage(page),
-            predicate: this.paginationUtil.parsePredicate(sort),
-            ascending: this.paginationUtil.parseAscending(sort),
-        };
-    }
-}
-
 export const userMgmtRoute: Routes = [
     {
         path: 'user-management',
         component: UserMgmtComponent,
         resolve: {
-            'pagingParams': UserResolvePagingParams,
+            'pagingParams': ResolvePagingParams,
         },
         data: {
             pageTitle: 'userManagement.home.title',

--- a/src/main/webapp/app/entities/oauth-client/oauth-client.component.ts
+++ b/src/main/webapp/app/entities/oauth-client/oauth-client.component.ts
@@ -1,7 +1,6 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { AlertService, EventManager, JhiLanguageService } from 'ng-jhipster';
 import { Subscription } from 'rxjs/Rx';
-import { Principal } from '../../shared';
 
 import { OAuthClient } from './oauth-client.model';
 import { OAuthClientService } from './oauth-client.service';
@@ -13,7 +12,6 @@ import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 })
 export class OAuthClientComponent implements OnInit, OnDestroy {
     oauthClients: OAuthClient[];
-    currentAccount: any;
     eventSubscriber: Subscription;
     objectKeys = Object.keys;
 
@@ -29,7 +27,6 @@ export class OAuthClientComponent implements OnInit, OnDestroy {
             private oauthClientService: OAuthClientService,
             private alertService: AlertService,
             private eventManager: EventManager,
-            private principal: Principal,
     ) {
         this.jhiLanguageService.setLocations(['oauthClient']);
     }
@@ -45,9 +42,6 @@ export class OAuthClientComponent implements OnInit, OnDestroy {
 
     ngOnInit() {
         this.loadAll();
-        this.principal.identity().then((account) => {
-            this.currentAccount = account;
-        });
         this.registerChangeInOAuthClients();
     }
 

--- a/src/main/webapp/app/entities/project/project.component.html
+++ b/src/main/webapp/app/entities/project/project.component.html
@@ -81,7 +81,7 @@
             </tbody>
         </table>
     </div>
-    <div *ngIf="projects">
+    <div *ngIf="projects && totalItems !== undefined">
         <div class="row justify-content-center">
             <jhi-item-count [page]="page" [total]="queryCount" [itemsPerPage]="itemsPerPage"></jhi-item-count>
         </div>

--- a/src/main/webapp/app/entities/project/project.component.ts
+++ b/src/main/webapp/app/entities/project/project.component.ts
@@ -2,7 +2,7 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subscription } from 'rxjs/Rx';
 import { AlertService, EventManager, JhiLanguageService, ParseLinks } from 'ng-jhipster';
-import { ITEMS_PER_PAGE, Principal, Project, ProjectService } from '../../shared';
+import { ITEMS_PER_PAGE, Project, ProjectService } from '../../shared';
 import {HttpErrorResponse, HttpResponse} from '@angular/common/http';
 import { PagingParams } from '../../shared/commons';
 
@@ -12,7 +12,6 @@ import { PagingParams } from '../../shared/commons';
 })
 export class ProjectComponent implements OnInit, OnDestroy {
     projects: Project[];
-    currentAccount: any;
     eventSubscriber: Subscription;
     itemsPerPage: number;
     links: any;
@@ -29,7 +28,6 @@ export class ProjectComponent implements OnInit, OnDestroy {
             private projectService: ProjectService,
             private alertService: AlertService,
             private eventManager: EventManager,
-            private principal: Principal,
             private parseLinks: ParseLinks,
             private activatedRoute: ActivatedRoute,
             private router: Router,
@@ -64,9 +62,6 @@ export class ProjectComponent implements OnInit, OnDestroy {
 
     ngOnInit() {
         this.loadAll();
-        this.principal.identity().then((account) => {
-            this.currentAccount = account;
-        });
         this.registerChangeInProjects();
     }
 

--- a/src/main/webapp/app/entities/project/project.component.ts
+++ b/src/main/webapp/app/entities/project/project.component.ts
@@ -4,6 +4,7 @@ import { Subscription } from 'rxjs/Rx';
 import { AlertService, EventManager, JhiLanguageService, ParseLinks } from 'ng-jhipster';
 import { ITEMS_PER_PAGE, Principal, Project, ProjectService } from '../../shared';
 import {HttpErrorResponse, HttpResponse} from '@angular/common/http';
+import { PagingParams } from '../../shared/commons';
 
 @Component({
     selector: 'jhi-project',
@@ -18,7 +19,7 @@ export class ProjectComponent implements OnInit, OnDestroy {
     page: any;
     predicate: any;
     queryCount: any;
-    reverse: any;
+    ascending: any;
     totalItems: number;
     routeData: any;
     previousPage: any;
@@ -35,11 +36,15 @@ export class ProjectComponent implements OnInit, OnDestroy {
     ) {
         this.projects = [];
         this.itemsPerPage = ITEMS_PER_PAGE;
-        this.routeData = this.activatedRoute.data.subscribe((data) => {
-            this.page = data['pagingParams'].page;
-            this.previousPage = data['pagingParams'].page;
-            this.reverse = data['pagingParams'].ascending;
-            this.predicate = data['pagingParams'].predicate;
+        const pagingParams$ = this.activatedRoute.data.map<any, PagingParams>(data => {
+            const fallback = { page: 1, predicate: 'id', ascending: true };
+            return data['pagingParams'] || fallback;
+        });
+        this.routeData = pagingParams$.subscribe(params => {
+            this.page = params.page;
+            this.previousPage = params.page;
+            this.ascending = params.ascending;
+            this.predicate = params.predicate;
         });
         this.jhiLanguageService.setLocations(['project', 'projectStatus']);
     }
@@ -82,7 +87,7 @@ export class ProjectComponent implements OnInit, OnDestroy {
     }
 
     sort() {
-        const result = [this.predicate + ',' + (this.reverse ? 'asc' : 'desc')];
+        const result = [this.predicate + ',' + (this.ascending ? 'asc' : 'desc')];
         if (this.predicate !== 'id') {
             result.push('id');
         }
@@ -108,7 +113,7 @@ export class ProjectComponent implements OnInit, OnDestroy {
             queryParams:
                     {
                         page: this.page,
-                        sort: this.predicate + ',' + (this.reverse ? 'asc' : 'desc'),
+                        sort: this.predicate + ',' + (this.ascending ? 'asc' : 'desc'),
                     },
         });
         this.loadAll();

--- a/src/main/webapp/app/entities/project/project.component.ts
+++ b/src/main/webapp/app/entities/project/project.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { Subscription } from 'rxjs/Rx';
+import { Observable, Subscription } from 'rxjs/Rx';
 import { AlertService, EventManager, JhiLanguageService, ParseLinks } from 'ng-jhipster';
 import { ITEMS_PER_PAGE, Project, ProjectService } from '../../shared';
 import {HttpErrorResponse, HttpResponse} from '@angular/common/http';
@@ -11,6 +11,8 @@ import { PagingParams } from '../../shared/commons';
     templateUrl: './project.component.html',
 })
 export class ProjectComponent implements OnInit, OnDestroy {
+    pagingParams$: Observable<PagingParams>;
+
     projects: Project[];
     eventSubscriber: Subscription;
     itemsPerPage: number;
@@ -34,11 +36,11 @@ export class ProjectComponent implements OnInit, OnDestroy {
     ) {
         this.projects = [];
         this.itemsPerPage = ITEMS_PER_PAGE;
-        const pagingParams$ = this.activatedRoute.data.map<any, PagingParams>(data => {
+        this.pagingParams$ = this.activatedRoute.data.map<any, PagingParams>(data => {
             const fallback = { page: 1, predicate: 'id', ascending: true };
             return data['pagingParams'] || fallback;
         });
-        this.routeData = pagingParams$.subscribe(params => {
+        this.routeData = this.pagingParams$.subscribe(params => {
             this.page = params.page;
             this.previousPage = params.page;
             this.ascending = params.ascending;
@@ -63,6 +65,10 @@ export class ProjectComponent implements OnInit, OnDestroy {
     ngOnInit() {
         this.loadAll();
         this.registerChangeInProjects();
+
+        this.pagingParams$.subscribe(() => {
+            this.loadAll();
+        });
     }
 
     ngOnDestroy() {

--- a/src/main/webapp/app/entities/project/project.route.ts
+++ b/src/main/webapp/app/entities/project/project.route.ts
@@ -12,6 +12,7 @@ import { ResolvePagingParams } from '../../shared/commons';
 export const projectRoute: Routes = [
     {
         path: 'project',
+        runGuardsAndResolvers: 'paramsOrQueryParamsChange',
         resolve: {
             'pagingParams': ResolvePagingParams,
         },

--- a/src/main/webapp/app/entities/revision/revision.component.html
+++ b/src/main/webapp/app/entities/revision/revision.component.html
@@ -5,7 +5,7 @@
     <div class="table-responsive">
         <table class="table table-striped">
             <thead>
-            <tr jhiSort [(predicate)]="predicate" [(ascending)]="reverse" [callback]="transition.bind(this)">
+            <tr jhiSort [(predicate)]="predicate" [(ascending)]="ascending" [callback]="transition.bind(this)">
                 <th jhiSortBy="id" ><span jhiTranslate="revisions.number">Revision Number</span><span class="fa fa-sort"></span></th>
                 <th jhiSortBy="timestamp" ><span jhiTranslate="audits.table.header.date">Date</span><span class="fa fa-sort"></span></th>
                 <th jhiSortBy="auditor" ><span jhiTranslate="revisions.author">Author</span><span class="fa fa-sort"></span></th>
@@ -83,7 +83,7 @@
             </tr>
         </table>
     </div>
-    <div>
+    <div *ngIf="totalItems !== undefined">
         <div class="row justify-content-center">
             <jhi-item-count [page]="page" [total]="queryCount" [itemsPerPage]="itemsPerPage"></jhi-item-count>
         </div>

--- a/src/main/webapp/app/entities/revision/revision.component.ts
+++ b/src/main/webapp/app/entities/revision/revision.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { AlertService, EventManager, JhiLanguageService, ParseLinks } from 'ng-jhipster';
-import { Subscription } from 'rxjs/Rx';
+import { Observable, Subscription } from 'rxjs/Rx';
 import { ITEMS_PER_PAGE } from '../../shared';
 
 import { Revision } from './revision.model';
@@ -14,6 +14,7 @@ import { PagingParams } from '../../shared/commons';
     templateUrl: './revision.component.html',
 })
 export class RevisionComponent implements OnInit, OnDestroy {
+    pagingParams$: Observable<PagingParams>;
 
     eventSubscriber: Subscription;
     revisions: Revision[];
@@ -39,11 +40,11 @@ export class RevisionComponent implements OnInit, OnDestroy {
             private router: Router,
     ) {
         this.itemsPerPage = ITEMS_PER_PAGE;
-        const pagingParams$ = this.activatedRoute.data.map<any, PagingParams>(data => {
+        this.pagingParams$ = this.activatedRoute.data.map<any, PagingParams>(data => {
             const fallback = { page: 1, predicate: 'id', ascending: true };
             return data['pagingParams'] || fallback;
         });
-        this.routeData = pagingParams$.subscribe(params => {
+        this.routeData = this.pagingParams$.subscribe(params => {
             this.page = params.page;
             this.previousPage = params.page;
             this.ascending = params.ascending;
@@ -55,6 +56,10 @@ export class RevisionComponent implements OnInit, OnDestroy {
     ngOnInit() {
         this.loadAll();
         this.registerChangeInRevisions();
+
+        this.pagingParams$.subscribe(() => {
+            this.loadAll();
+        });
     }
 
     ngOnDestroy() {

--- a/src/main/webapp/app/entities/revision/revision.component.ts
+++ b/src/main/webapp/app/entities/revision/revision.component.ts
@@ -15,7 +15,6 @@ import { PagingParams } from '../../shared/commons';
 })
 export class RevisionComponent implements OnInit, OnDestroy {
 
-    currentAccount: any;
     eventSubscriber: Subscription;
     revisions: Revision[];
     error: any;

--- a/src/main/webapp/app/entities/revision/revision.component.ts
+++ b/src/main/webapp/app/entities/revision/revision.component.ts
@@ -7,6 +7,7 @@ import { ITEMS_PER_PAGE } from '../../shared';
 import { Revision } from './revision.model';
 import { RevisionService } from './revision.service';
 import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
+import { PagingParams } from '../../shared/commons';
 
 @Component({
     selector: 'jhi-revisions',
@@ -26,7 +27,7 @@ export class RevisionComponent implements OnInit, OnDestroy {
     page: any;
     predicate: any;
     previousPage: any;
-    reverse: any;
+    ascending: any;
     routeData: any;
 
     constructor(
@@ -39,11 +40,15 @@ export class RevisionComponent implements OnInit, OnDestroy {
             private router: Router,
     ) {
         this.itemsPerPage = ITEMS_PER_PAGE;
-        this.routeData = this.activatedRoute.data.subscribe((data) => {
-            this.page = data['pagingParams'].page;
-            this.previousPage = data['pagingParams'].page;
-            this.reverse = data['pagingParams'].ascending;
-            this.predicate = data['pagingParams'].predicate;
+        const pagingParams$ = this.activatedRoute.data.map<any, PagingParams>(data => {
+            const fallback = { page: 1, predicate: 'id', ascending: true };
+            return data['pagingParams'] || fallback;
+        });
+        this.routeData = pagingParams$.subscribe(params => {
+            this.page = params.page;
+            this.previousPage = params.page;
+            this.ascending = params.ascending;
+            this.predicate = params.predicate;
         });
         this.jhiLanguageService.setLocations(['audits']);
     }
@@ -78,7 +83,7 @@ export class RevisionComponent implements OnInit, OnDestroy {
     }
 
     sort() {
-        const result = [this.predicate + ',' + (this.reverse ? 'asc' : 'desc')];
+        const result = [this.predicate + ',' + (this.ascending ? 'asc' : 'desc')];
         if (this.predicate !== 'id') {
             result.push('id');
         }
@@ -97,7 +102,7 @@ export class RevisionComponent implements OnInit, OnDestroy {
             queryParams:
                     {
                         page: this.page,
-                        sort: this.predicate + ',' + (this.reverse ? 'asc' : 'desc'),
+                        sort: this.predicate + ',' + (this.ascending ? 'asc' : 'desc'),
                     },
         });
         this.loadAll();

--- a/src/main/webapp/app/entities/revision/revision.route.ts
+++ b/src/main/webapp/app/entities/revision/revision.route.ts
@@ -10,6 +10,7 @@ export const revisionRoute: Routes = [
     {
         path: 'revisions',
         component: RevisionComponent,
+        runGuardsAndResolvers: 'paramsOrQueryParamsChange',
         resolve: {
             'pagingParams': ResolvePagingParams,
         },

--- a/src/main/webapp/app/entities/role/role-dialog.component.ts
+++ b/src/main/webapp/app/entities/role/role-dialog.component.ts
@@ -4,7 +4,7 @@ import { ActivatedRoute } from '@angular/router';
 import { NgbActiveModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { AlertService, EventManager, JhiLanguageService } from 'ng-jhipster';
 import { Role } from '../../admin/user-management/role.model';
-import { AuthorityService, Principal, Project, ProjectService } from '../../shared';
+import { AuthorityService, Project, ProjectService } from '../../shared';
 
 import { RolePopupService } from './role-popup.service';
 import { RoleService } from './role.service';
@@ -20,7 +20,6 @@ export class RoleDialogComponent implements OnInit {
     authorities: any[];
     projects: Project[];
     isSaving: boolean;
-    currentAccount: any;
 
     constructor(
             public activeModal: NgbActiveModal,
@@ -29,7 +28,6 @@ export class RoleDialogComponent implements OnInit {
             private roleService: RoleService,
             private authorityService: AuthorityService,
             private projectService: ProjectService,
-            private principal: Principal,
             private eventManager: EventManager,
     ) {
         this.jhiLanguageService.addLocation('role');

--- a/src/main/webapp/app/entities/source-data/source-data.component.html
+++ b/src/main/webapp/app/entities/source-data/source-data.component.html
@@ -15,7 +15,7 @@
     <div class="table-responsive" *ngIf="sourceData">
         <table class="table table-striped">
             <thead>
-            <tr jhiSort [(predicate)]="predicate" [(ascending)]="reverse" [callback]="transition.bind(this)">
+            <tr jhiSort [(predicate)]="predicate" [(ascending)]="ascending" [callback]="transition.bind(this)">
                 <th jhiSortBy="id" ><span jhiTranslate="global.field.id">ID</span><span class="fa fa-sort"></span></th>
                 <th jhiSortBy="sourceDataType"><span jhiTranslate="managementPortalApp.sourceData.sourceDataType">Source Data Type</span><span class="fa fa-sort"></span></th>
                 <th jhiSortBy="sourceDataName"><span jhiTranslate="managementPortalApp.sourceData.sourceDataName">Source Data Name</span><span class="fa fa-sort"></span></th>
@@ -62,7 +62,7 @@
             </tbody>
         </table>
     </div>
-    <div *ngIf="sourceData">
+    <div *ngIf="sourceData && totalItems !== undefined">
         <div class="row justify-content-center">
             <jhi-item-count [page]="page" [total]="queryCount" [itemsPerPage]="itemsPerPage"></jhi-item-count>
         </div>

--- a/src/main/webapp/app/entities/source-data/source-data.component.ts
+++ b/src/main/webapp/app/entities/source-data/source-data.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { Subscription } from 'rxjs/Rx';
+import { Observable, Subscription } from 'rxjs/Rx';
 import { EventManager, ParseLinks, JhiLanguageService, AlertService } from 'ng-jhipster';
 
 import { SourceData } from './source-data.model';
@@ -14,6 +14,8 @@ import { PagingParams } from '../../shared/commons';
     templateUrl: './source-data.component.html'
 })
 export class SourceDataComponent implements OnInit, OnDestroy {
+    pagingParams$: Observable<PagingParams>;
+
     sourceData: SourceData[];
     eventSubscriber: Subscription;
     itemsPerPage: number;
@@ -36,11 +38,11 @@ export class SourceDataComponent implements OnInit, OnDestroy {
     ) {
         this.sourceData = [];
         this.itemsPerPage = ITEMS_PER_PAGE;
-        const pagingParams$ = this.activatedRoute.data.map<any, PagingParams>(data => {
+        this.pagingParams$ = this.activatedRoute.data.map<any, PagingParams>(data => {
             const fallback = { page: 1, predicate: 'id', ascending: true };
             return data['pagingParams'] || fallback;
         });
-        this.routeData = pagingParams$.subscribe(params => {
+        this.routeData = this.pagingParams$.subscribe(params => {
             this.page = params.page;
             this.previousPage = params.page;
             this.ascending = params.ascending;
@@ -64,6 +66,10 @@ export class SourceDataComponent implements OnInit, OnDestroy {
     ngOnInit() {
         this.loadAll();
         this.registerChangeInSourceData();
+
+        this.pagingParams$.subscribe(() => {
+            this.loadAll();
+        });
     }
 
     ngOnDestroy() {

--- a/src/main/webapp/app/entities/source-data/source-data.component.ts
+++ b/src/main/webapp/app/entities/source-data/source-data.component.ts
@@ -7,6 +7,7 @@ import { SourceData } from './source-data.model';
 import { SourceDataService } from './source-data.service';
 import { ITEMS_PER_PAGE, Principal } from '../../shared';
 import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
+import { PagingParams } from '../../shared/commons';
 
 @Component({
     selector: 'jhi-source-data',
@@ -21,7 +22,7 @@ export class SourceDataComponent implements OnInit, OnDestroy {
     page: any;
     predicate: any;
     queryCount: any;
-    reverse: any;
+    ascending: any;
     totalItems: number;
     routeData: any;
     previousPage: any;
@@ -37,11 +38,15 @@ export class SourceDataComponent implements OnInit, OnDestroy {
     ) {
         this.sourceData = [];
         this.itemsPerPage = ITEMS_PER_PAGE;
-        this.routeData = this.activatedRoute.data.subscribe((data) => {
-            this.page = data['pagingParams'].page;
-            this.previousPage = data['pagingParams'].page;
-            this.reverse = data['pagingParams'].ascending;
-            this.predicate = data['pagingParams'].predicate;
+        const pagingParams$ = this.activatedRoute.data.map<any, PagingParams>(data => {
+            const fallback = { page: 1, predicate: 'id', ascending: true };
+            return data['pagingParams'] || fallback;
+        });
+        this.routeData = pagingParams$.subscribe(params => {
+            this.page = params.page;
+            this.previousPage = params.page;
+            this.ascending = params.ascending;
+            this.predicate = params.predicate;
         });
         this.jhiLanguageService.setLocations(['sourceData', 'processingState']);
     }
@@ -83,7 +88,7 @@ export class SourceDataComponent implements OnInit, OnDestroy {
     }
 
     sort() {
-        const result = [this.predicate + ',' + (this.reverse ? 'asc' : 'desc')];
+        const result = [this.predicate + ',' + (this.ascending ? 'asc' : 'desc')];
         if (this.predicate !== 'id') {
             result.push('id');
         }
@@ -108,7 +113,7 @@ export class SourceDataComponent implements OnInit, OnDestroy {
         this.router.navigate(['/source-data'], { queryParams:
             {
                 page: this.page,
-                sort: this.predicate + ',' + (this.reverse ? 'asc' : 'desc')
+                sort: this.predicate + ',' + (this.ascending ? 'asc' : 'desc')
             }
         });
         this.loadAll();

--- a/src/main/webapp/app/entities/source-data/source-data.component.ts
+++ b/src/main/webapp/app/entities/source-data/source-data.component.ts
@@ -5,7 +5,7 @@ import { EventManager, ParseLinks, JhiLanguageService, AlertService } from 'ng-j
 
 import { SourceData } from './source-data.model';
 import { SourceDataService } from './source-data.service';
-import { ITEMS_PER_PAGE, Principal } from '../../shared';
+import { ITEMS_PER_PAGE } from '../../shared';
 import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import { PagingParams } from '../../shared/commons';
 
@@ -15,7 +15,6 @@ import { PagingParams } from '../../shared/commons';
 })
 export class SourceDataComponent implements OnInit, OnDestroy {
     sourceData: SourceData[];
-    currentAccount: any;
     eventSubscriber: Subscription;
     itemsPerPage: number;
     links: any;
@@ -32,7 +31,6 @@ export class SourceDataComponent implements OnInit, OnDestroy {
         private alertService: AlertService,
         private eventManager: EventManager,
         private parseLinks: ParseLinks,
-        private principal: Principal,
         private activatedRoute: ActivatedRoute,
         private router: Router
     ) {
@@ -65,9 +63,6 @@ export class SourceDataComponent implements OnInit, OnDestroy {
     }
     ngOnInit() {
         this.loadAll();
-        this.principal.identity().then((account) => {
-            this.currentAccount = account;
-        });
         this.registerChangeInSourceData();
     }
 

--- a/src/main/webapp/app/entities/source-data/source-data.route.ts
+++ b/src/main/webapp/app/entities/source-data/source-data.route.ts
@@ -14,6 +14,7 @@ export const sourceDataRoute: Routes = [
   {
     path: 'source-data',
     component: SourceDataComponent,
+    runGuardsAndResolvers: 'paramsOrQueryParamsChange',
     resolve: {
       'pagingParams': ResolvePagingParams
     },

--- a/src/main/webapp/app/entities/source-type/source-type.component.html
+++ b/src/main/webapp/app/entities/source-type/source-type.component.html
@@ -15,7 +15,7 @@
     <div class="table-responsive" *ngIf="sourceTypes">
         <table class="table table-striped">
             <thead>
-            <tr jhiSort [(predicate)]="predicate" [(ascending)]="reverse" [callback]="transition.bind(this)">
+            <tr jhiSort [(predicate)]="predicate" [(ascending)]="ascending" [callback]="transition.bind(this)">
             <th jhiSortBy="id"><span jhiTranslate="global.field.id">ID</span><span class="fa fa-sort"></span></th>
             <th jhiSortBy="producer"><span jhiTranslate="managementPortalApp.sourceType.producer">Producer</span><span class="fa fa-sort"></span></th>
             <th jhiSortBy="model"><span jhiTranslate="managementPortalApp.sourceType.model">Model</span><span class="fa fa-sort"></span></th>
@@ -72,7 +72,7 @@
             </tbody>
         </table>
     </div>
-    <div *ngIf="sourceTypes">
+    <div *ngIf="sourceTypes && totalItems !== undefined">
         <div class="row justify-content-center">
             <jhi-item-count [page]="page" [total]="queryCount" [itemsPerPage]="itemsPerPage"></jhi-item-count>
         </div>

--- a/src/main/webapp/app/entities/source-type/source-type.component.ts
+++ b/src/main/webapp/app/entities/source-type/source-type.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { AlertService, EventManager, JhiLanguageService, ParseLinks } from 'ng-jhipster';
-import { Subscription } from 'rxjs/Rx';
+import { Observable, Subscription } from 'rxjs/Rx';
 import { ITEMS_PER_PAGE } from '../../shared';
 
 import { SourceType } from './source-type.model';
@@ -14,6 +14,7 @@ import { PagingParams } from '../../shared/commons';
     templateUrl: './source-type.component.html',
 })
 export class SourceTypeComponent implements OnInit, OnDestroy {
+    pagingParams$: Observable<PagingParams>;
 
     sourceTypes: SourceType[];
     eventSubscriber: Subscription;
@@ -38,11 +39,11 @@ export class SourceTypeComponent implements OnInit, OnDestroy {
     ) {
         this.sourceTypes = [];
         this.itemsPerPage = ITEMS_PER_PAGE;
-        const pagingParams$ = this.activatedRoute.data.map<any, PagingParams>(data => {
+        this.pagingParams$ = this.activatedRoute.data.map<any, PagingParams>(data => {
             const fallback = { page: 1, predicate: 'id', ascending: true };
             return data['pagingParams'] || fallback;
         });
-        this.routeData = pagingParams$.subscribe(params => {
+        this.routeData = this.pagingParams$.subscribe(params => {
             this.page = params.page;
             this.previousPage = params.page;
             this.ascending = params.ascending;
@@ -67,6 +68,10 @@ export class SourceTypeComponent implements OnInit, OnDestroy {
     ngOnInit() {
         this.loadAll();
         this.registerChangeInSourceTypes();
+
+        this.pagingParams$.subscribe(() => {
+            this.loadAll();
+        });
     }
 
     ngOnDestroy() {

--- a/src/main/webapp/app/entities/source-type/source-type.component.ts
+++ b/src/main/webapp/app/entities/source-type/source-type.component.ts
@@ -2,7 +2,7 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { AlertService, EventManager, JhiLanguageService, ParseLinks } from 'ng-jhipster';
 import { Subscription } from 'rxjs/Rx';
-import { ITEMS_PER_PAGE, Principal } from '../../shared';
+import { ITEMS_PER_PAGE } from '../../shared';
 
 import { SourceType } from './source-type.model';
 import { SourceTypeService } from './source-type.service';
@@ -16,7 +16,6 @@ import { PagingParams } from '../../shared/commons';
 export class SourceTypeComponent implements OnInit, OnDestroy {
 
     sourceTypes: SourceType[];
-    currentAccount: any;
     eventSubscriber: Subscription;
     itemsPerPage: number;
     links: any;
@@ -33,7 +32,6 @@ export class SourceTypeComponent implements OnInit, OnDestroy {
             private sourceTypeService: SourceTypeService,
             private alertService: AlertService,
             private eventManager: EventManager,
-            private principal: Principal,
             private parseLinks: ParseLinks,
             private activatedRoute: ActivatedRoute,
             private router: Router,
@@ -68,9 +66,6 @@ export class SourceTypeComponent implements OnInit, OnDestroy {
 
     ngOnInit() {
         this.loadAll();
-        this.principal.identity().then((account) => {
-            this.currentAccount = account;
-        });
         this.registerChangeInSourceTypes();
     }
 

--- a/src/main/webapp/app/entities/source-type/source-type.component.ts
+++ b/src/main/webapp/app/entities/source-type/source-type.component.ts
@@ -7,6 +7,7 @@ import { ITEMS_PER_PAGE, Principal } from '../../shared';
 import { SourceType } from './source-type.model';
 import { SourceTypeService } from './source-type.service';
 import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
+import { PagingParams } from '../../shared/commons';
 
 @Component({
     selector: 'jhi-source-type',
@@ -22,7 +23,7 @@ export class SourceTypeComponent implements OnInit, OnDestroy {
     page: any;
     predicate: any;
     queryCount: any;
-    reverse: any;
+    ascending: any;
     totalItems: number;
     routeData: any;
     previousPage: any;
@@ -39,11 +40,15 @@ export class SourceTypeComponent implements OnInit, OnDestroy {
     ) {
         this.sourceTypes = [];
         this.itemsPerPage = ITEMS_PER_PAGE;
-        this.routeData = this.activatedRoute.data.subscribe((data) => {
-            this.page = data['pagingParams'].page;
-            this.previousPage = data['pagingParams'].page;
-            this.reverse = data['pagingParams'].ascending;
-            this.predicate = data['pagingParams'].predicate;
+        const pagingParams$ = this.activatedRoute.data.map<any, PagingParams>(data => {
+            const fallback = { page: 1, predicate: 'id', ascending: true };
+            return data['pagingParams'] || fallback;
+        });
+        this.routeData = pagingParams$.subscribe(params => {
+            this.page = params.page;
+            this.previousPage = params.page;
+            this.ascending = params.ascending;
+            this.predicate = params.predicate;
         });
         this.jhiLanguageService.setLocations(['sourceType', 'sourceTypeScope']);
     }
@@ -87,7 +92,7 @@ export class SourceTypeComponent implements OnInit, OnDestroy {
     }
 
     sort() {
-        const result = [this.predicate + ',' + (this.reverse ? 'asc' : 'desc')];
+        const result = [this.predicate + ',' + (this.ascending ? 'asc' : 'desc')];
         if (this.predicate !== 'id') {
             result.push('id');
         }
@@ -109,11 +114,11 @@ export class SourceTypeComponent implements OnInit, OnDestroy {
     }
 
     transition() {
-        this.router.navigate(['/source-types'], {
+        this.router.navigate(['/source-type'], {
             queryParams:
                     {
                         page: this.page,
-                        sort: this.predicate + ',' + (this.reverse ? 'asc' : 'desc'),
+                        sort: this.predicate + ',' + (this.ascending ? 'asc' : 'desc'),
                     },
         });
         this.loadAll();

--- a/src/main/webapp/app/entities/source-type/source-type.route.ts
+++ b/src/main/webapp/app/entities/source-type/source-type.route.ts
@@ -13,6 +13,7 @@ export const sourceTypeRoute: Routes = [
     {
         path: 'source-type',
         component: SourceTypeComponent,
+        runGuardsAndResolvers: 'paramsOrQueryParamsChange',
         resolve: {
             'pagingParams': ResolvePagingParams,
         },

--- a/src/main/webapp/app/entities/source/general-source.route.ts
+++ b/src/main/webapp/app/entities/source/general-source.route.ts
@@ -13,6 +13,7 @@ export const sourceRoute: Routes = [
         resolve: {
             'pagingParams': ResolvePagingParams,
         },
+        runGuardsAndResolvers: 'paramsOrQueryParamsChange',
         component: GeneralSourceComponent,
         data: {
             authorities: [SYSTEM_ADMIN],

--- a/src/main/webapp/app/entities/subject/general.subject.route.ts
+++ b/src/main/webapp/app/entities/subject/general.subject.route.ts
@@ -10,6 +10,7 @@ import { ResolvePagingParams } from '../../shared/commons';
 export const subjectRoute: Routes = [
     {
         path: 'subject',
+        runGuardsAndResolvers: 'paramsOrQueryParamsChange',
         resolve: {
             'pagingParams': ResolvePagingParams,
         },

--- a/src/main/webapp/app/shared/commons.ts
+++ b/src/main/webapp/app/shared/commons.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { ActivatedRouteSnapshot, Resolve, RouterStateSnapshot } from '@angular/router';
+import { ActivatedRouteSnapshot, Resolve } from '@angular/router';
 import { PaginationUtil } from 'ng-jhipster';
 
 @Injectable()
@@ -8,7 +8,7 @@ export class ResolvePagingParams implements Resolve<any> {
     constructor(private paginationUtil: PaginationUtil) {
     }
 
-    resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
+    resolve(route: ActivatedRouteSnapshot): PagingParams {
         const page = route.queryParams['page'] ? route.queryParams['page'] : '1';
         const sort = route.queryParams['sort'] ? route.queryParams['sort'] : 'id,asc';
         return {
@@ -17,4 +17,10 @@ export class ResolvePagingParams implements Resolve<any> {
             ascending: this.paginationUtil.parseAscending(sort),
         };
     }
+}
+
+export interface PagingParams {
+    page: number;
+    predicate: string;
+    ascending: boolean;
 }

--- a/src/main/webapp/app/shared/source/source.component.html
+++ b/src/main/webapp/app/shared/source/source.component.html
@@ -26,7 +26,7 @@
     <div class="table-responsive" *ngIf="sources">
         <table class="table table-striped">
             <thead>
-            <tr jhiSort [(predicate)]="predicate" [(ascending)]="reverse" [callback]="transition.bind(this)">
+            <tr jhiSort [(predicate)]="predicate" [(ascending)]="ascending" [callback]="transition.bind(this)">
             <th jhiSortBy="id" ><span jhiTranslate="global.field.id">ID</span><span class="fa fa-sort"></span></th>
             <th jhiSortBy="sourceName" ><span jhiTranslate="managementPortalApp.source.sourceName">Source Name</span><span class="fa fa-sort"></span></th>
             <th><span jhiTranslate="managementPortalApp.source.expectedSourceName">Expected Source Name</span></th>
@@ -102,7 +102,7 @@
             </tbody>
         </table>
     </div>
-    <div *ngIf="sources">
+    <div *ngIf="sources && totalItems !== undefined">
         <div class="row justify-content-center">
             <jhi-item-count [page]="page" [total]="queryCount" [itemsPerPage]="itemsPerPage"></jhi-item-count>
         </div>

--- a/src/main/webapp/app/shared/source/source.component.ts
+++ b/src/main/webapp/app/shared/source/source.component.ts
@@ -16,6 +16,7 @@ import { Source } from './source.model';
 import { SourceService } from './source.service';
 import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import { SourceData } from '../../entities/source-data';
+import { PagingParams } from '../commons';
 
 @Component({
     selector: 'jhi-sources',
@@ -34,7 +35,7 @@ export class SourceComponent implements OnInit, OnDestroy, OnChanges {
     page: any;
     predicate: any;
     queryCount: any;
-    reverse: any;
+    ascending: any;
     totalItems: number;
     routeData: any;
     previousPage: any;
@@ -49,18 +50,15 @@ export class SourceComponent implements OnInit, OnDestroy, OnChanges {
                 private router: Router) {
         this.sources = [];
         this.itemsPerPage = ITEMS_PER_PAGE;
-        this.routeData = this.activatedRoute.data.subscribe((data) => {
-            if (data['pagingParams']) {
-                this.page = data['pagingParams'].page;
-                this.previousPage = data['pagingParams'].page;
-                this.reverse = data['pagingParams'].ascending;
-                this.predicate = data['pagingParams'].predicate;
-            } else {
-                this.page = 1;
-                this.previousPage = 1;
-                this.predicate = 'id';
-                this.reverse = true;
-            }
+        const pagingParams$ = this.activatedRoute.data.map<any, PagingParams>(data => {
+            const fallback = { page: 1, predicate: 'id', ascending: true };
+            return data['pagingParams'] || fallback;
+        });
+        this.routeData = pagingParams$.subscribe(params => {
+            this.page = params.page;
+            this.previousPage = params.page;
+            this.ascending = params.ascending;
+            this.predicate = params.predicate;
         });
         this.jhiLanguageService.addLocation('source');
     }
@@ -133,7 +131,7 @@ export class SourceComponent implements OnInit, OnDestroy, OnChanges {
     }
 
     sort() {
-        const result = [this.predicate + ',' + (this.reverse ? 'asc' : 'desc')];
+        const result = [this.predicate + ',' + (this.ascending ? 'asc' : 'desc')];
         if (this.predicate !== 'id') {
             result.push('id');
         }
@@ -160,7 +158,7 @@ export class SourceComponent implements OnInit, OnDestroy, OnChanges {
                 queryParams:
                         {
                             page: this.page,
-                            sort: this.predicate + ',' + (this.reverse ? 'asc' : 'desc'),
+                            sort: this.predicate + ',' + (this.ascending ? 'asc' : 'desc'),
                         },
             });
         }

--- a/src/main/webapp/app/shared/subject/source-assigner/source-assigner.component.ts
+++ b/src/main/webapp/app/shared/subject/source-assigner/source-assigner.component.ts
@@ -2,7 +2,6 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { NgbActiveModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { AlertService, EventManager, JhiLanguageService } from 'ng-jhipster';
-import { Principal } from '../..';
 import { MinimalSource, SourceService} from '../../source';
 import { SubjectPopupService } from '../subject-popup.service';
 
@@ -21,7 +20,6 @@ export class SubjectSourceAssignerDialogComponent implements OnInit {
     assignableSources: MinimalSource[];
     assignedSources: MinimalSource[];
     isSaving: boolean;
-    currentAccount: any;
 
     constructor(
             public activeModal: NgbActiveModal,
@@ -29,7 +27,6 @@ export class SubjectSourceAssignerDialogComponent implements OnInit {
             private alertService: AlertService,
             private subjectService: SubjectService,
             private sourceService: SourceService,
-            private principal: Principal,
             private eventManager: EventManager,
     ) {
         this.jhiLanguageService.addLocation('subject');

--- a/src/main/webapp/app/shared/subject/subject.component.html
+++ b/src/main/webapp/app/shared/subject/subject.component.html
@@ -27,7 +27,7 @@
     <div class="table-responsive" *ngIf="subjects">
         <table class="table table-striped">
             <thead>
-            <tr jhiSort [(predicate)]="predicate" [(ascending)]="reverse" [callback]="transition.bind(this)">
+            <tr jhiSort [(predicate)]="predicate" [(ascending)]="ascending" [callback]="transition.bind(this)">
             <th jhiSortBy="user.login" ><span jhiTranslate="managementPortalApp.subject.subjectId">subjectId</span><span class="fa fa-sort"></span></th>
             <th jhiSortBy="externalId" ><span jhiTranslate="managementPortalApp.subject.externalId">Enternal Id</span><span class="fa fa-sort"></span></th>
                 <th jhiSortBy="user.activated"><span jhiTranslate="managementPortalApp.subject.status.title">Status</span><span class="fa fa-sort"></span></th>
@@ -140,7 +140,7 @@
             </tbody>
         </table>
     </div>
-    <div *ngIf="subjects">
+    <div *ngIf="subjects && totalItems !== undefined">
         <div class="row justify-content-center">
             <jhi-item-count [page]="page" [total]="queryCount" [itemsPerPage]="itemsPerPage"></jhi-item-count>
         </div>

--- a/src/main/webapp/app/shared/subject/subject.component.ts
+++ b/src/main/webapp/app/shared/subject/subject.component.ts
@@ -15,6 +15,7 @@ import { ITEMS_PER_PAGE, Principal, Project } from '..';
 import { Subject } from './subject.model';
 import { SubjectService } from './subject.service';
 import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
+import { PagingParams } from '../commons';
 
 @Component({
     selector: 'jhi-subjects',
@@ -30,7 +31,7 @@ export class SubjectComponent implements OnInit, OnDestroy, OnChanges {
     page: any;
     predicate: any;
     queryCount: any;
-    reverse: any;
+    ascending: any;
     totalItems: number;
     routeData: any;
     previousPage: any;
@@ -49,18 +50,15 @@ export class SubjectComponent implements OnInit, OnDestroy, OnChanges {
     ) {
         this.subjects = [];
         this.itemsPerPage = ITEMS_PER_PAGE;
-        this.routeData = this.activatedRoute.data.subscribe((data) => {
-            if (data['pagingParams']) {
-                this.page = data['pagingParams'].page;
-                this.previousPage = data['pagingParams'].page;
-                this.reverse = data['pagingParams'].ascending;
-                this.predicate = data['pagingParams'].predicate;
-            } else {
-                this.page = 1;
-                this.previousPage = 1;
-                this.predicate = 'user.login';
-                this.reverse = true;
-            }
+        const pagingParams$ = this.activatedRoute.data.map<any, PagingParams>(data => {
+            const fallback = { page: 1, predicate: 'user.login', ascending: true };
+            return data['pagingParams'] || fallback;
+        });
+        this.routeData = pagingParams$.subscribe(params => {
+            this.page = params.page;
+            this.previousPage = params.page;
+            this.ascending = params.ascending;
+            this.predicate = params.predicate;
         });
         this.jhiLanguageService.addLocation('subject');
     }
@@ -137,7 +135,7 @@ export class SubjectComponent implements OnInit, OnDestroy, OnChanges {
     }
 
     sort() {
-        return [this.predicate + ',' + (this.reverse ? 'asc' : 'desc')];
+        return [this.predicate + ',' + (this.ascending ? 'asc' : 'desc')];
     }
 
     private onSuccess(data, headers) {
@@ -160,7 +158,7 @@ export class SubjectComponent implements OnInit, OnDestroy, OnChanges {
                 queryParams:
                         {
                             page: this.page,
-                            sort: this.predicate + ',' + (this.reverse ? 'asc' : 'desc'),
+                            sort: this.predicate + ',' + (this.ascending ? 'asc' : 'desc'),
                         },
             });
         }

--- a/src/main/webapp/app/shared/user/common-user-management.component.ts
+++ b/src/main/webapp/app/shared/user/common-user-management.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnChanges, OnInit, SimpleChange, SimpleChanges } from '@angular/core';
-import { AlertService, EventManager, JhiLanguageService, ParseLinks } from 'ng-jhipster';
+import { EventManager, JhiLanguageService } from 'ng-jhipster';
 
 import { ITEMS_PER_PAGE, Project, User, UserService } from '..';
 
@@ -8,7 +8,6 @@ import { ITEMS_PER_PAGE, Project, User, UserService } from '..';
     templateUrl: './common-user-management.component.html'
 })
 export class CommonUserMgmtComponent implements OnInit, OnChanges {
-    currentAccount: any;
     users: User[];
     error: any;
     success: any;
@@ -26,8 +25,6 @@ export class CommonUserMgmtComponent implements OnInit, OnChanges {
     constructor(
             private jhiLanguageService: JhiLanguageService,
             private userService: UserService,
-            private parseLinks: ParseLinks,
-            private alertService: AlertService,
             private eventManager: EventManager,
     ) {
         this.itemsPerPage = ITEMS_PER_PAGE;


### PR DESCRIPTION
Related to #530.
Navigation is tracked in history on _entity-specific pages_, but back/forward buttons did not cause page content to reload. This MR fixes it.

Original behavior:
https://user-images.githubusercontent.com/22550677/103892439-e4bc1480-50eb-11eb-9cbc-a6f00384b0d7.mov

Improved behavior:
https://user-images.githubusercontent.com/22550677/103892456-eab1f580-50eb-11eb-890a-333494beee5e.mov

