### PR TITLE
Fixed references to other dependencies

### DIFF
--- a/radar-auth/build.gradle
+++ b/radar-auth/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.github.johnrengelman.shadow' version '5.0.0'
+    id 'com.github.johnrengelman.shadow' version '6.1.0'
 }
 
 apply plugin: 'maven-publish'
@@ -7,10 +7,10 @@ apply plugin: 'com.jfrog.bintray'
 apply plugin: 'com.jfrog.artifactory'
 
 ext {
-    jacksonVersion = '2.11.3'
-    jacksonYamlVersion = '2.11.3'
+    jacksonVersion = '2.11.4'
+    jacksonYamlVersion = '2.11.4'
     okhttpVersion = '4.9.0'
-    oauthJwtVersion = '3.11.0'
+    oauthJwtVersion = '3.12.0'
     commonsCodecVersion = '1.15'
     slf4jVersion = '1.7.30'
 }

--- a/radar-auth/deprecated-auth0/build.gradle
+++ b/radar-auth/deprecated-auth0/build.gradle
@@ -15,6 +15,6 @@ dependencies {
 }
 
 shadowJar {
-    relocate 'com', 'shadow.com'
-    relocate 'org', 'shadow.org'
+    relocate 'com.auth0.jwt', 'shadow.com.auth0.jwt'
+    relocate 'org.bouncycastle', 'shadow.org.bouncycastle'
 }


### PR DESCRIPTION
Apparently, shadowJar also renames dependencies that are not directly packaged. This PR fixes that by only relocating the relevant namespaces and none other.