### PR TITLE
Continue with other verifiers on SignatureVerificationException

### DIFF
--- a/radar-auth/src/main/java/org/radarcns/auth/authentication/TokenValidator.java
+++ b/radar-auth/src/main/java/org/radarcns/auth/authentication/TokenValidator.java
@@ -150,10 +150,9 @@ public class TokenValidator {
                 }
                 return new JwtRadarToken(jwt);
             } catch (SignatureVerificationException sve) {
-                LOGGER.warn("Client presented a token with an incorrect signature, fetching public "
-                        + "keys again. Token: {}", token);
+                LOGGER.debug("Client presented a token with an incorrect signature. Token: {}",
+                        token);
                 refresh();
-                return validateAccessToken(token);
             } catch (JWTVerificationException ex) {
                 LOGGER.debug("Verifier {} with implementation {} did not accept token {}",
                         verifier.toString(), verifier.getClass().toString(), token);

--- a/radar-auth/src/main/java/org/radarcns/auth/authentication/TokenValidator.java
+++ b/radar-auth/src/main/java/org/radarcns/auth/authentication/TokenValidator.java
@@ -132,6 +132,10 @@ public class TokenValidator {
      * @throws TokenValidationException If the token can not be validated.
      */
     public RadarToken validateAccessToken(String token) throws TokenValidationException {
+        return validateAccessToken(token, true);
+    }
+
+    private RadarToken validateAccessToken(String token, boolean tryRefresh) {
         List<JWTVerifier> localVerifiers = getVerifiers();
         for (JWTVerifier verifier : localVerifiers) {
             try {
@@ -150,9 +154,12 @@ public class TokenValidator {
                 }
                 return new JwtRadarToken(jwt);
             } catch (SignatureVerificationException sve) {
-                LOGGER.debug("Client presented a token with an incorrect signature. Token: {}",
-                        token);
-                refresh();
+                LOGGER.debug("Client presented a token with an incorrect signature.");
+                if (tryRefresh) {
+                    LOGGER.info("Fetching public keys again...");
+                    refresh();
+                    return validateAccessToken(token, false);
+                }
             } catch (JWTVerificationException ex) {
                 LOGGER.debug("Verifier {} with implementation {} did not accept token {}",
                         verifier.toString(), verifier.getClass().toString(), token);


### PR DESCRIPTION
This allows public keys with different signatures to be used (for example from different MP deployments)