### PR TITLE
Separate npm installs in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ FROM openjdk:8-jdk as builder
 # install node
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
     apt-get install -yq nodejs build-essential && \
-    npm install -g npm yarn
+    npm install -g npm && \
+    npm install -g yarn
 
 # installing the node packages before adding the src directory will allow us to re-use these image layers when only the souce code changes
 WORKDIR /app


### PR DESCRIPTION
- The Docker build fails with the error:```The command '/bin/sh -c curl -sL https://deb.nodesource.com/setup_12.x | bash - && apt-get install -yq nodejs build-essential && npm install -g npm yarn' returned a non-zero code: 1```
- Separating the npm commands fixes it