### PR TITLE
Ensure that only strong passwords are allowed

### DIFF
--- a/src/main/java/org/radarcns/management/service/util/PasswordUtil.java
+++ b/src/main/java/org/radarcns/management/service/util/PasswordUtil.java
@@ -23,9 +23,9 @@ public class PasswordUtil {
             Pattern.compile("[^a-zA-Z0-9]")
     };
 
-    /** Calculate password strength. A score of at least 40 is good. */
+    /** Check whether given password is too weak. */
     public boolean isPasswordWeak(String password) {
-        return Arrays.stream(patterns).allMatch(p -> p.matcher(password).find())
-                && password.length() >= 8;
+        return !Arrays.stream(patterns).allMatch(p -> p.matcher(password).find())
+                || password.length() < 8;
     }
 }

--- a/src/main/java/org/radarcns/management/service/util/PasswordUtil.java
+++ b/src/main/java/org/radarcns/management/service/util/PasswordUtil.java
@@ -24,25 +24,8 @@ public class PasswordUtil {
     };
 
     /** Calculate password strength. A score of at least 40 is good. */
-    public int score(String password) {
-        int passedMatches = (int) Arrays.stream(patterns)
-                .filter(p -> p.matcher(password).find())
-                .count();
-
-        int force = 2 * password.length() + 10 * passedMatches;
-
-        // penality (short password)
-        if (password.length() <= 8 && force > 20) {
-            force = 20;
-        }
-        // penality (poor variety of characters)
-        if (passedMatches == 1 && force > 10) {
-            force = 10;
-        }
-        if (passedMatches == 2 && force > 30) {
-            force = 30;
-        }
-
-        return force;
+    public boolean isPasswordWeak(String password) {
+        return Arrays.stream(patterns).allMatch(p -> p.matcher(password).find())
+                && password.length() >= 8;
     }
 }

--- a/src/main/java/org/radarcns/management/service/util/PasswordUtil.java
+++ b/src/main/java/org/radarcns/management/service/util/PasswordUtil.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2021. The Hyve
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * See the file LICENSE in the root of this repository.
+ */
+
+package org.radarcns.management.service.util;
+
+import java.util.Arrays;
+import java.util.regex.Pattern;
+
+/** Password utility. */
+public class PasswordUtil {
+    private final Pattern[] patterns = {
+            // numeric
+            Pattern.compile("[0-9]"),
+            // letter
+            Pattern.compile("[a-zA-Z]"),
+            // symbol
+            Pattern.compile("[^a-zA-Z0-9]")
+    };
+
+    /** Calculate password strength. A score of at least 40 is good. */
+    public int score(String password) {
+        int passedMatches = (int) Arrays.stream(patterns)
+                .filter(p -> p.matcher(password).find())
+                .count();
+
+        int force = 2 * password.length() + 10 * passedMatches;
+
+        // penality (short password)
+        if (password.length() <= 8 && force > 20) {
+            force = 20;
+        }
+        // penality (poor variety of characters)
+        if (passedMatches == 1 && force > 10) {
+            force = 10;
+        }
+        if (passedMatches == 2 && force > 30) {
+            force = 30;
+        }
+
+        return force;
+    }
+}

--- a/src/main/java/org/radarcns/management/web/rest/AccountResource.java
+++ b/src/main/java/org/radarcns/management/web/rest/AccountResource.java
@@ -209,6 +209,8 @@ public class AccountResource {
     private void checkPasswordLength(String password) {
         if (passwordUtil.score(password) < 40) {
             throw new BadRequestException("Incorrect password", null, "incorrect_password");
+        } else if (password.length() > 100) {
+            throw new BadRequestException("Password too long", null, "password_too_long");
         }
     }
 }

--- a/src/main/java/org/radarcns/management/web/rest/AccountResource.java
+++ b/src/main/java/org/radarcns/management/web/rest/AccountResource.java
@@ -208,7 +208,9 @@ public class AccountResource {
 
     private void checkPasswordLength(String password) {
         if (passwordUtil.isPasswordWeak(password)) {
-            throw new BadRequestException("Weak password. Use a password with more variety of numeric, alphabetical and symbol characters.", null, "weak_password");
+            throw new BadRequestException(
+                    "Weak password. Use a password with more variety of numeric, alphabetical and "
+                            + "symbol characters.", null, "weak_password");
         } else if (password.length() > 100) {
             throw new BadRequestException("Password too long", null, "password_too_long");
         }

--- a/src/main/java/org/radarcns/management/web/rest/AccountResource.java
+++ b/src/main/java/org/radarcns/management/web/rest/AccountResource.java
@@ -208,7 +208,7 @@ public class AccountResource {
 
     private void checkPasswordLength(String password) {
         if (passwordUtil.score(password) < 40) {
-            throw new BadRequestException("Incorrect password", null, "incorrect_password");
+            throw new BadRequestException("Weak password. Use a password with more variety of numeric, alphabetical and symbol characters.", null, "weak_password");
         } else if (password.length() > 100) {
             throw new BadRequestException("Password too long", null, "password_too_long");
         }

--- a/src/main/java/org/radarcns/management/web/rest/AccountResource.java
+++ b/src/main/java/org/radarcns/management/web/rest/AccountResource.java
@@ -207,7 +207,7 @@ public class AccountResource {
     }
 
     private void checkPasswordLength(String password) {
-        if (passwordUtil.score(password) < 40) {
+        if (passwordUtil.isPasswordWeak(password)) {
             throw new BadRequestException("Weak password. Use a password with more variety of numeric, alphabetical and symbol characters.", null, "weak_password");
         } else if (password.length() > 100) {
             throw new BadRequestException("Password too long", null, "password_too_long");

--- a/src/main/webapp/app/account/password-reset/finish/password-reset-finish.component.html
+++ b/src/main/webapp/app/account/password-reset/finish/password-reset-finish.component.html
@@ -24,13 +24,17 @@
                 The password and its confirmation do not match!
             </div>
 
+            <div class="alert alert-danger" *ngIf="weakPassword" jhiTranslate="global.messages.error.weakpassword">
+                Password strength must be at least four bars. Add symbols and numbers to increase the score.
+            </div>
+
             <div *ngIf="!keyMissing">
                 <form *ngIf="!success" name="form" role="form" (ngSubmit)="finishReset()" #passwordForm="ngForm">
                     <div class="form-group">
                         <label class="form-control-label" for="password" jhiTranslate="global.form.newpassword">New password</label>
                         <input type="password" class="form-control" id="password" name="password" #passwordInput="ngModel"
                                placeholder="{{'global.form.newpassword.placeholder' | translate}}"
-                               [(ngModel)]="resetAccount.password" minlength=4 maxlength=50 required>
+                               [(ngModel)]="resetAccount.password" minlength=8 maxlength=100 required>
                         <div *ngIf="passwordInput.dirty && passwordInput.invalid">
                             <small class="form-text text-danger"
                                *ngIf="passwordInput.errors.required" jhiTranslate="global.messages.validate.newpassword.required">
@@ -38,11 +42,11 @@
                             </small>
                             <small class="form-text text-danger"
                                *ngIf="passwordInput.errors.minlength" jhiTranslate="global.messages.validate.newpassword.minlength">
-                                Your password is required to be at least 4 characters.
+                                Your password is required to be at least 8 characters.
                             </small>
                             <small class="form-text text-danger"
                                *ngIf="passwordInput.errors.maxlength" jhiTranslate="global.messages.validate.newpassword.maxlength">
-                                Your password cannot be longer than 50 characters.
+                                Your password cannot be longer than 100 characters.
                             </small>
                         </div>
                         <jhi-password-strength-bar [passwordToCheck]="resetAccount.password"></jhi-password-strength-bar>
@@ -52,7 +56,7 @@
                         <label class="form-control-label" for="confirmPassword" jhiTranslate="global.form.confirmpassword">New password confirmation</label>
                         <input type="password" class="form-control" id="confirmPassword" name="confirmPassword" #confirmPasswordInput="ngModel"
                                placeholder="{{'global.form.confirmpassword.placeholder' | translate}}"
-                               [(ngModel)]="confirmPassword" minlength=4 maxlength=50 required>
+                               [(ngModel)]="confirmPassword" minlength=8 maxlength=100 required>
                         <div *ngIf="confirmPasswordInput.dirty && confirmPasswordInput.invalid">
                             <small class="form-text text-danger"
                                *ngIf="confirmPasswordInput.errors.required" jhiTranslate="global.messages.validate.confirmpassword.required">
@@ -60,11 +64,11 @@
                             </small>
                             <small class="form-text text-danger"
                                *ngIf="confirmPasswordInput.errors.minlength" jhiTranslate="global.messages.validate.confirmpassword.minlength">
-                                Your password confirmation is required to be at least 4 characters.
+                                Your password confirmation is required to be at least 8 characters.
                             </small>
                             <small class="form-text text-danger"
                                *ngIf="confirmPasswordInput.errors.maxlength" jhiTranslate="global.messages.validate.confirmpassword.maxlength">
-                                Your password confirmation cannot be longer than 50 characters.
+                                Your password confirmation cannot be longer than 100 characters.
                             </small>
                         </div>
                     </div>

--- a/src/main/webapp/app/account/password-reset/finish/password-reset-finish.component.ts
+++ b/src/main/webapp/app/account/password-reset/finish/password-reset-finish.component.ts
@@ -5,7 +5,7 @@ import { JhiLanguageService } from 'ng-jhipster';
 import { LoginModalService } from '../../../shared';
 
 import { PasswordResetFinish } from './password-reset-finish.service';
-import { Password } from "../../password/password.service";
+import { Password } from '../../password/password.service';
 
 @Component({
     selector: 'jhi-password-reset-finish',

--- a/src/main/webapp/app/account/password-reset/finish/password-reset-finish.component.ts
+++ b/src/main/webapp/app/account/password-reset/finish/password-reset-finish.component.ts
@@ -5,6 +5,7 @@ import { JhiLanguageService } from 'ng-jhipster';
 import { LoginModalService } from '../../../shared';
 
 import { PasswordResetFinish } from './password-reset-finish.service';
+import { Password } from "../../password/password.service";
 
 @Component({
     selector: 'jhi-password-reset-finish',
@@ -12,6 +13,7 @@ import { PasswordResetFinish } from './password-reset-finish.service';
 })
 export class PasswordResetFinishComponent implements OnInit, AfterViewInit {
     confirmPassword: string;
+    weakPassword: string;
     doNotMatch: string;
     error: string;
     keyMissing: boolean;
@@ -23,6 +25,7 @@ export class PasswordResetFinishComponent implements OnInit, AfterViewInit {
     constructor(
             private jhiLanguageService: JhiLanguageService,
             private passwordResetFinish: PasswordResetFinish,
+            private passwordService: Password,
             private loginModalService: LoginModalService,
             private route: ActivatedRoute,
             private elementRef: ElementRef, private renderer: Renderer,
@@ -45,18 +48,24 @@ export class PasswordResetFinishComponent implements OnInit, AfterViewInit {
     }
 
     finishReset() {
-        this.doNotMatch = null;
         this.error = null;
+        this.success = null;
+        this.doNotMatch = null;
+        this.weakPassword = null;
+        if (this.passwordService.measureStrength(this.resetAccount.password) < 40) {
+            this.weakPassword = 'ERROR';
+        }
         if (this.resetAccount.password !== this.confirmPassword) {
             this.doNotMatch = 'ERROR';
-        } else {
+        }
+
+        if (this.weakPassword == null && this.doNotMatch == null) {
             this.passwordResetFinish.save({
                 key: this.key,
                 newPassword: this.resetAccount.password,
             }).subscribe(() => {
                 this.success = 'OK';
             }, () => {
-                this.success = null;
                 this.error = 'ERROR';
             });
         }

--- a/src/main/webapp/app/account/password/password-strength-bar.component.ts
+++ b/src/main/webapp/app/account/password/password-strength-bar.component.ts
@@ -1,4 +1,5 @@
 import { Component, ElementRef, Input, Renderer } from '@angular/core';
+import { Password } from "./password.service";
 
 @Component({
     selector: 'jhi-password-strength-bar',
@@ -22,35 +23,11 @@ export class PasswordStrengthBarComponent {
 
     colors = ['#F00', '#F90', '#FF0', '#9F0', '#0F0'];
 
-    constructor(private renderer: Renderer, private elementRef: ElementRef) {
-    }
-
-    measureStrength(p: string): number {
-
-        let force = 0;
-        const regex = /[$-/:-?{-~!"^_`\[\]]/g; // "
-        const lowerLetters = /[a-z]+/.test(p);
-        const upperLetters = /[A-Z]+/.test(p);
-        const numbers = /[0-9]+/.test(p);
-        const symbols = regex.test(p);
-
-        const flags = [lowerLetters, upperLetters, numbers, symbols];
-        const passedMatches = flags.filter((isMatchedFlag: boolean) => {
-            return isMatchedFlag === true;
-        }).length;
-
-        force += 2 * p.length + ((p.length >= 10) ? 1 : 0);
-        force += passedMatches * 10;
-
-        // penality (short password)
-        force = (p.length <= 6) ? Math.min(force, 10) : force;
-
-        // penality (poor variety of characters)
-        force = (passedMatches === 1) ? Math.min(force, 10) : force;
-        force = (passedMatches === 2) ? Math.min(force, 20) : force;
-        force = (passedMatches === 3) ? Math.min(force, 40) : force;
-
-        return force;
+    constructor(
+      private renderer: Renderer,
+      private elementRef: ElementRef,
+      private passwordService: Password,
+    ) {
     }
 
     getColor(s: number): any {
@@ -72,7 +49,7 @@ export class PasswordStrengthBarComponent {
     @Input()
     set passwordToCheck(password: string) {
         if (password) {
-            const c = this.getColor(this.measureStrength(password));
+            const c = this.getColor(this.passwordService.measureStrength(password));
             const element = this.elementRef.nativeElement;
             if (element.className) {
                 this.renderer.setElementClass(element, element.className, false);

--- a/src/main/webapp/app/account/password/password-strength-bar.component.ts
+++ b/src/main/webapp/app/account/password/password-strength-bar.component.ts
@@ -32,13 +32,13 @@ export class PasswordStrengthBarComponent {
 
     getColor(s: number): any {
         let idx = 0;
-        if (s <= 10) {
+        if (s < 20) {
             idx = 0;
-        } else if (s <= 20) {
+        } else if (s < 30) {
             idx = 1;
-        } else if (s <= 30) {
+        } else if (s < 40) {
             idx = 2;
-        } else if (s <= 40) {
+        } else if (s < 55) {
             idx = 3;
         } else {
             idx = 4;

--- a/src/main/webapp/app/account/password/password-strength-bar.component.ts
+++ b/src/main/webapp/app/account/password/password-strength-bar.component.ts
@@ -1,5 +1,5 @@
 import { Component, ElementRef, Input, Renderer } from '@angular/core';
-import { Password } from "./password.service";
+import { Password } from './password.service';
 
 @Component({
     selector: 'jhi-password-strength-bar',

--- a/src/main/webapp/app/account/password/password.component.html
+++ b/src/main/webapp/app/account/password/password.component.html
@@ -14,13 +14,17 @@
                 The password and its confirmation do not match!
             </div>
 
+            <div class="alert alert-danger" *ngIf="weakPassword" jhiTranslate="global.messages.error.weakpassword">
+                Password strength must be at least four bars. Add symbols and numbers to increase the score.
+            </div>
+
             <form name="form" role="form" (ngSubmit)="changePassword()" #passwordForm="ngForm">
 
                 <div class="form-group">
                     <label class="form-control-label" for="password" jhiTranslate="global.form.newpassword">New password</label>
                     <input type="password" class="form-control" id="password" name="password" #passwordInput="ngModel"
                     placeholder="{{'global.form.newpassword.placeholder' | translate}}"
-                           [(ngModel)]="password" minlength=4 maxlength=50 required>
+                           [(ngModel)]="password" minlength=8 maxlength=100 required>
                     <div *ngIf="passwordInput.dirty && passwordInput.invalid">
                         <small class="form-text text-danger"
                            *ngIf="passwordInput.errors.required" jhiTranslate="global.messages.validate.newpassword.required">
@@ -28,11 +32,11 @@
                         </small>
                         <small class="form-text text-danger"
                            *ngIf="passwordInput.errors.minlength" jhiTranslate="global.messages.validate.newpassword.minlength">
-                            Your password is required to be at least 4 characters.
+                            Your password is required to be at least 8 characters.
                         </small>
                         <small class="form-text text-danger"
                            *ngIf="passwordInput.errors.maxlength" jhiTranslate="global.messages.validate.newpassword.maxlength">
-                            Your password cannot be longer than 50 characters.
+                            Your password cannot be longer than 100 characters.
                         </small>
                     </div>
                     <jhi-password-strength-bar [passwordToCheck]="password"></jhi-password-strength-bar>
@@ -41,7 +45,7 @@
                     <label class="form-control-label" for="confirmPassword" jhiTranslate="global.form.confirmpassword">New password confirmation</label>
                     <input type="password" class="form-control" id="confirmPassword" name="confirmPassword" #confirmPasswordInput="ngModel"
                     placeholder="{{'global.form.confirmpassword.placeholder' | translate}}"
-                           [(ngModel)]="confirmPassword" minlength=4 maxlength=50 required>
+                           [(ngModel)]="confirmPassword" minlength=8 maxlength=100 required>
                     <div *ngIf="confirmPasswordInput.dirty && confirmPasswordInput.invalid">
                         <small class="form-text text-danger"
                            *ngIf="confirmPasswordInput.errors.required" jhiTranslate="global.messages.validate.confirmpassword.required">
@@ -49,11 +53,11 @@
                         </small>
                         <small class="form-text text-danger"
                            *ngIf="confirmPasswordInput.errors.minlength" jhiTranslate="global.messages.validate.confirmpassword.minlength">
-                            Your confirmation password is required to be at least 4 characters.
+                            Your confirmation password is required to be at least 8 characters.
                         </small>
                         <small class="form-text text-danger"
                            *ngIf="confirmPasswordInput.errors.maxlength" jhiTranslate="global.messages.validate.confirmpassword.maxlength">
-                            Your confirmation password cannot be longer than 50 characters.
+                            Your confirmation password cannot be longer than 100 characters.
                         </small>
                     </div>
                 </div>

--- a/src/main/webapp/app/account/password/password.component.ts
+++ b/src/main/webapp/app/account/password/password.component.ts
@@ -10,6 +10,7 @@ import { Password } from './password.service';
 })
 export class PasswordComponent implements OnInit {
     doNotMatch: string;
+    weakPassword: string;
     error: string;
     success: string;
     account: any;
@@ -25,25 +26,29 @@ export class PasswordComponent implements OnInit {
     }
 
     ngOnInit() {
-        this.principal.identity().then((account) => {
-            this.account = account;
-        });
+        this.principal.identity()
+            .then((account) => this.account = account);
     }
 
     changePassword() {
+        this.error = null;
+        this.success = null;
+        this.doNotMatch = null;
+        this.weakPassword = null;
+        if (this.passwordService.measureStrength(this.password) < 40) {
+            this.weakPassword = 'ERROR';
+        }
         if (this.password !== this.confirmPassword) {
-            this.error = null;
-            this.success = null;
             this.doNotMatch = 'ERROR';
-        } else {
-            this.doNotMatch = null;
-            this.passwordService.save(this.password).subscribe(() => {
-                this.error = null;
-                this.success = 'OK';
-            }, () => {
-                this.success = null;
-                this.error = 'ERROR';
-            });
+        }
+
+        if (this.weakPassword == null && this.doNotMatch == null) {
+            this.passwordService.save(this.password)
+                .subscribe(() => {
+                    this.success = 'OK';
+                }, () => {
+                    this.error = 'ERROR';
+                });
         }
     }
 }

--- a/src/main/webapp/app/account/password/password.service.ts
+++ b/src/main/webapp/app/account/password/password.service.ts
@@ -13,19 +13,14 @@ export class Password {
     }
 
     measureStrength(p: string): number {
-        let force = 0;
-        const regex = /[$-/:-?{-~!"^_`\[\]]/g; // "
         const letters = /[a-zA-Z]+/.test(p);
         const numbers = /[0-9]+/.test(p);
-        const symbols = regex.test(p);
+        const symbols = /[^a-zA-Z0-9]/.test(p);
 
         const flags = [letters, numbers, symbols];
-        const passedMatches = flags.filter((isMatchedFlag: boolean) => {
-            return isMatchedFlag === true;
-        }).length;
+        const passedMatches = flags.filter((isMatchedFlag) => isMatchedFlag).length;
 
-        force += 2 * p.length + ((p.length >= 10) ? 1 : 0);
-        force += passedMatches * 10;
+        let force = 2 * p.length + passedMatches * 10;
 
         // penality (short password)
         force = (p.length <= 8) ? Math.min(force, 20) : force;

--- a/src/main/webapp/app/account/password/password.service.ts
+++ b/src/main/webapp/app/account/password/password.service.ts
@@ -11,4 +11,29 @@ export class Password {
     save(newPassword: string): Observable<any> {
         return this.http.post('api/account/change_password', newPassword);
     }
+
+    measureStrength(p: string): number {
+        let force = 0;
+        const regex = /[$-/:-?{-~!"^_`\[\]]/g; // "
+        const letters = /[a-zA-Z]+/.test(p);
+        const numbers = /[0-9]+/.test(p);
+        const symbols = regex.test(p);
+
+        const flags = [letters, numbers, symbols];
+        const passedMatches = flags.filter((isMatchedFlag: boolean) => {
+            return isMatchedFlag === true;
+        }).length;
+
+        force += 2 * p.length + ((p.length >= 10) ? 1 : 0);
+        force += passedMatches * 10;
+
+        // penality (short password)
+        force = (p.length <= 8) ? Math.min(force, 20) : force;
+
+        // penality (poor variety of characters)
+        force = (passedMatches === 1) ? Math.min(force, 10) : force;
+        force = (passedMatches === 2) ? Math.min(force, 30) : force;
+
+        return force;
+    }
 }

--- a/src/main/webapp/app/account/password/password.service.ts
+++ b/src/main/webapp/app/account/password/password.service.ts
@@ -23,7 +23,7 @@ export class Password {
         let force = 2 * p.length + passedMatches * 10;
 
         // penality (short password)
-        force = (p.length <= 8) ? Math.min(force, 20) : force;
+        force = (p.length < 8) ? Math.min(force, 20) : force;
 
         // penality (poor variety of characters)
         force = (passedMatches === 1) ? Math.min(force, 10) : force;

--- a/src/main/webapp/i18n/en/global.json
+++ b/src/main/webapp/i18n/en/global.json
@@ -65,19 +65,20 @@
                 }
             },
             "error": {
-                "dontmatch": "The password and its confirmation do not match!"
+                "dontmatch": "The password and its confirmation do not match!",
+                "weakpassword": "Password strength must be at least four bars. Add symbols and numbers to increase the strength."
             },
             "validate": {
                 "newpassword": {
                     "required": "Your password is required.",
-                    "minlength": "Your password is required to be at least 4 characters.",
-                    "maxlength": "Your password cannot be longer than 50 characters.",
+                    "minlength": "Your password is required to be at least 8 characters.",
+                    "maxlength": "Your password cannot be longer than 100 characters.",
                     "strength": "Password strength:"
                 },
                 "confirmpassword": {
                     "required": "Your confirmation password is required.",
-                    "minlength": "Your confirmation password is required to be at least 4 characters.",
-                    "maxlength": "Your confirmation password cannot be longer than 50 characters."
+                    "minlength": "Your confirmation password is required to be at least 8 characters.",
+                    "maxlength": "Your confirmation password cannot be longer than 100 characters."
                 },
                 "email": {
                     "required": "Your email is required.",

--- a/src/main/webapp/i18n/nl/global.json
+++ b/src/main/webapp/i18n/nl/global.json
@@ -65,19 +65,20 @@
                 }
             },
             "error": {
-                "dontmatch" : "Het wachtwoord en zijn bevestiging komen niet overeen!"
+                "dontmatch" : "Het wachtwoord en zijn bevestiging komen niet overeen!",
+                "weakpassword": "De wachtwoordsterkte moet tenminste vier streepjes zijn. Voeg symbolen en getallen toe om de sterkte te verbeteren."
             },
             "validate": {
                 "newpassword": {
                     "required": "Uw wachtwoord is vereist.",
-                    "minlength": "Uw wachtwoord moet minstens 5 tekens lang zijn.",
-                    "maxlength": "Uw wachtwoord kan niet langer zijn dan 50 tekens.",
+                    "minlength": "Uw wachtwoord moet minstens 8 tekens lang zijn.",
+                    "maxlength": "Uw wachtwoord kan niet langer zijn dan 100 tekens.",
                     "strength": "Wachtwoord sterkte:"
                 },
                 "confirmpassword": {
                     "required": "Uw wachtwoord bevestiging is vereist.",
-                    "minlength": "Uw wachtwoord bevestiging moet minstens 5 tekens lang zijn.",
-                    "maxlength": "Uw wachtwoord bevestiging kan niet langer zijn dan 50 tekens."
+                    "minlength": "Uw wachtwoord bevestiging moet minstens 8 tekens lang zijn.",
+                    "maxlength": "Uw wachtwoord bevestiging kan niet langer zijn dan 100 tekens."
                 },
                 "email": {
                     "required": "Uw email is vereist.",

--- a/src/test/javascript/e2e/account/account.spec.ts
+++ b/src/test/javascript/e2e/account/account.spec.ts
@@ -41,7 +41,7 @@ describe('account', () => {
         expect((await modalTitle.getAttribute('jhiTranslate'))).toMatch(expect1);
 
         await username.sendKeys('admin');
-        await password.sendKeys('admin123$');
+        await password.sendKeys('admin');
         await element(by.css('button[type=submit]')).click();
 
         await browser.waitForAngular();

--- a/src/test/javascript/e2e/account/account.spec.ts
+++ b/src/test/javascript/e2e/account/account.spec.ts
@@ -93,16 +93,9 @@ describe('account', () => {
         await element(by.css('button[type=submit]')).click();
 
         await browser.waitForAngular();
+        browser.sleep(3000);
 
-        await navBarPage.clickOnAccountMenu();
-        await browser.waitForAngular();
-        await element(by.css('[routerLink="password"]')).click();
-        // change back to default
-        await password.clear();
-        await password.sendKeys('admin');
-        await element(by.id('confirmPassword')).clear();
-        await element(by.id('confirmPassword')).sendKeys('admin');
-        await element(by.css('button[type=submit]')).click();
+        const successElements = element.all(by.css('.alert-success span'));
+        expect((await successElements.isPresent()));
     });
-
 });

--- a/src/test/javascript/e2e/account/account.spec.ts
+++ b/src/test/javascript/e2e/account/account.spec.ts
@@ -41,7 +41,7 @@ describe('account', () => {
         expect((await modalTitle.getAttribute('jhiTranslate'))).toMatch(expect1);
 
         await username.sendKeys('admin');
-        await password.sendKeys('admin');
+        await password.sendKeys('admin123$');
         await element(by.css('button[type=submit]')).click();
 
         await browser.waitForAngular();
@@ -74,8 +74,8 @@ describe('account', () => {
         const pageTitle = element.all(by.css('h2')).first();
         expect((await pageTitle.getAttribute('jhiTranslate'))).toMatch(expect1);
 
-        await password.sendKeys('newpassword');
-        await element(by.id('confirmPassword')).sendKeys('newpassword');
+        await password.sendKeys('newpassword123$');
+        await element(by.id('confirmPassword')).sendKeys('newpassword123$');
         await element(by.css('button[type=submit]')).click();
 
         const expect2 = /password.messages.success/;
@@ -89,7 +89,7 @@ describe('account', () => {
         await navBarPage.clickOnSignIn();
 
         await username.sendKeys('admin');
-        await password.sendKeys('newpassword');
+        await password.sendKeys('newpassword123$');
         await element(by.css('button[type=submit]')).click();
 
         await browser.waitForAngular();

--- a/src/test/javascript/spec/app/account/password-reset/finish/password-reset-finish.component.spec.ts
+++ b/src/test/javascript/spec/app/account/password-reset/finish/password-reset-finish.component.spec.ts
@@ -6,7 +6,7 @@ import { ManagementPortalTestModule } from '../../../../test.module';
 import { PasswordResetFinishComponent } from '../../../../../../../main/webapp/app/account/password-reset/finish/password-reset-finish.component';
 import { PasswordResetFinish } from '../../../../../../../main/webapp/app/account/password-reset/finish/password-reset-finish.service';
 import { MockActivatedRoute } from '../../../../helpers/mock-route.service';
-import { Password } from "../../../../../../../main/webapp/app/account";
+import { Password } from '../../../../../../../main/webapp/app/account';
 
 describe('Component Tests', () => {
 

--- a/src/test/javascript/spec/app/account/password-reset/finish/password-reset-finish.component.spec.ts
+++ b/src/test/javascript/spec/app/account/password-reset/finish/password-reset-finish.component.spec.ts
@@ -6,6 +6,7 @@ import { ManagementPortalTestModule } from '../../../../test.module';
 import { PasswordResetFinishComponent } from '../../../../../../../main/webapp/app/account/password-reset/finish/password-reset-finish.component';
 import { PasswordResetFinish } from '../../../../../../../main/webapp/app/account/password-reset/finish/password-reset-finish.service';
 import { MockActivatedRoute } from '../../../../helpers/mock-route.service';
+import { Password } from "../../../../../../../main/webapp/app/account";
 
 describe('Component Tests', () => {
 
@@ -37,7 +38,8 @@ describe('Component Tests', () => {
                     {
                         provide: ElementRef,
                         useValue: new ElementRef(null)
-                    }
+                    },
+                    Password,
                 ]
             }).overrideTemplate(PasswordResetFinishComponent, 'overrideTemplate')
                     .createComponent(PasswordResetFinishComponent);

--- a/src/test/javascript/spec/app/account/password/password-strength-bar.component.spec.ts
+++ b/src/test/javascript/spec/app/account/password/password-strength-bar.component.spec.ts
@@ -1,17 +1,20 @@
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 
 import { PasswordStrengthBarComponent } from '../../../../../../main/webapp/app/account/password/password-strength-bar.component';
+import { Password } from "../../../../../../main/webapp/app/account";
 
 describe('Component Tests', () => {
 
     describe('PasswordStrengthBarComponent', () => {
 
+        let serviceFixture: ComponentFixture<Password>;
+        let service: Password;
         let comp: PasswordStrengthBarComponent;
         let fixture: ComponentFixture<PasswordStrengthBarComponent>;
 
         beforeEach(async(() => {
             TestBed.configureTestingModule({
-                declarations: [PasswordStrengthBarComponent]
+              declarations: [PasswordStrengthBarComponent, Password]
             })
                     .overrideTemplate(PasswordStrengthBarComponent, '')
                     .compileComponents();
@@ -20,22 +23,24 @@ describe('Component Tests', () => {
         beforeEach(() => {
             fixture = TestBed.createComponent(PasswordStrengthBarComponent);
             comp = fixture.componentInstance;
+            serviceFixture = TestBed.createComponent(Password);
+            service = serviceFixture.componentInstance;
         });
 
         describe('PasswordStrengthBarComponents', () => {
             it('should initialize with default values', () => {
-                expect(comp.measureStrength('')).toBe(0);
+                expect(service.measureStrength('')).toBe(0);
                 expect(comp.colors).toEqual(['#F00', '#F90', '#FF0', '#9F0', '#0F0']);
                 expect(comp.getColor(0).idx).toBe(1);
                 expect(comp.getColor(0).col).toBe(comp.colors[0]);
             });
 
             it('should increase strength upon password value change', () => {
-                expect(comp.measureStrength('')).toBe(0);
-                expect(comp.measureStrength('aa')).toBeGreaterThanOrEqual(comp.measureStrength(''));
-                expect(comp.measureStrength('aa^6')).toBeGreaterThanOrEqual(comp.measureStrength('aa'));
-                expect(comp.measureStrength('Aa090(**)')).toBeGreaterThanOrEqual(comp.measureStrength('aa^6'));
-                expect(comp.measureStrength('Aa090(**)+-07365')).toBeGreaterThanOrEqual(comp.measureStrength('Aa090(**)'));
+                expect(service.measureStrength('')).toBe(0);
+                expect(service.measureStrength('aa')).toBeGreaterThanOrEqual(service.measureStrength(''));
+                expect(service.measureStrength('aa^6')).toBeGreaterThanOrEqual(service.measureStrength('aa'));
+                expect(service.measureStrength('Aa090(**)')).toBeGreaterThanOrEqual(service.measureStrength('aa^6'));
+                expect(service.measureStrength('Aa090(**)+-07365')).toBeGreaterThanOrEqual(service.measureStrength('Aa090(**)'));
             });
 
              it('should change the color based on strength', () => {

--- a/src/test/javascript/spec/app/account/password/password-strength-bar.component.spec.ts
+++ b/src/test/javascript/spec/app/account/password/password-strength-bar.component.spec.ts
@@ -6,15 +6,20 @@ import { Password } from '../../../../../../main/webapp/app/account';
 describe('Component Tests', () => {
 
     describe('PasswordStrengthBarComponent', () => {
-
-        let serviceFixture: ComponentFixture<Password>;
         let service: Password;
         let comp: PasswordStrengthBarComponent;
         let fixture: ComponentFixture<PasswordStrengthBarComponent>;
 
         beforeEach(async(() => {
+            service = new Password(null)
             TestBed.configureTestingModule({
-              declarations: [PasswordStrengthBarComponent, Password]
+              declarations: [PasswordStrengthBarComponent],
+              providers: [
+                {
+                  provider: Password,
+                  use: service,
+                }
+              ]
             })
                     .overrideTemplate(PasswordStrengthBarComponent, '')
                     .compileComponents();
@@ -23,8 +28,6 @@ describe('Component Tests', () => {
         beforeEach(() => {
             fixture = TestBed.createComponent(PasswordStrengthBarComponent);
             comp = fixture.componentInstance;
-            serviceFixture = TestBed.createComponent(Password);
-            service = serviceFixture.componentInstance;
         });
 
         describe('PasswordStrengthBarComponents', () => {

--- a/src/test/javascript/spec/app/account/password/password-strength-bar.component.spec.ts
+++ b/src/test/javascript/spec/app/account/password/password-strength-bar.component.spec.ts
@@ -16,8 +16,8 @@ describe('Component Tests', () => {
               declarations: [PasswordStrengthBarComponent],
               providers: [
                 {
-                  provider: Password,
-                  use: service,
+                  provide: Password,
+                  useValue: service,
                 }
               ]
             })

--- a/src/test/javascript/spec/app/account/password/password-strength-bar.component.spec.ts
+++ b/src/test/javascript/spec/app/account/password/password-strength-bar.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 
 import { PasswordStrengthBarComponent } from '../../../../../../main/webapp/app/account/password/password-strength-bar.component';
-import { Password } from "../../../../../../main/webapp/app/account";
+import { Password } from '../../../../../../main/webapp/app/account';
 
 describe('Component Tests', () => {
 

--- a/src/test/javascript/spec/app/account/password/password-strength-bar.component.spec.ts
+++ b/src/test/javascript/spec/app/account/password/password-strength-bar.component.spec.ts
@@ -46,12 +46,12 @@ describe('Component Tests', () => {
                 expect(service.measureStrength('Aa090(**)+-07365')).toBeGreaterThanOrEqual(service.measureStrength('Aa090(**)'));
             });
 
-             it('should change the color based on strength', () => {
-                expect(comp.getColor(0).col).toBe(comp.colors[0]);
-                expect(comp.getColor(11).col).toBe(comp.colors[1]);
-                expect(comp.getColor(22).col).toBe(comp.colors[2]);
-                expect(comp.getColor(33).col).toBe(comp.colors[3]);
-                expect(comp.getColor(44).col).toBe(comp.colors[4]);
+            it('should change the color based on strength', () => {
+                expect(comp.getColor(10).col).toBe(comp.colors[0]);
+                expect(comp.getColor(20).col).toBe(comp.colors[1]);
+                expect(comp.getColor(30).col).toBe(comp.colors[2]);
+                expect(comp.getColor(40).col).toBe(comp.colors[3]);
+                expect(comp.getColor(55).col).toBe(comp.colors[4]);
             });
         });
     });

--- a/src/test/javascript/spec/app/account/password/password-strength-bar.component.spec.ts
+++ b/src/test/javascript/spec/app/account/password/password-strength-bar.component.spec.ts
@@ -11,7 +11,7 @@ describe('Component Tests', () => {
         let fixture: ComponentFixture<PasswordStrengthBarComponent>;
 
         beforeEach(async(() => {
-            service = new Password(null)
+            service = new Password(null);
             TestBed.configureTestingModule({
               declarations: [PasswordStrengthBarComponent],
               providers: [

--- a/src/test/javascript/spec/app/account/password/password.component.spec.ts
+++ b/src/test/javascript/spec/app/account/password/password.component.spec.ts
@@ -34,8 +34,8 @@ describe('Component Tests', () => {
 
         it('should show error if passwords do not match', () => {
             // GIVEN
-            comp.password = 'password1';
-            comp.confirmPassword = 'password2';
+            comp.password = 'password1$';
+            comp.confirmPassword = 'password2$';
             // WHEN
             comp.changePassword();
             // THEN
@@ -47,19 +47,19 @@ describe('Component Tests', () => {
         it('should call Auth.changePassword when passwords match', () => {
             // GIVEN
             spyOn(service, 'save').and.returnValue(Observable.of(true));
-            comp.password = comp.confirmPassword = 'myPassword';
+            comp.password = comp.confirmPassword = 'myPassword1$';
 
             // WHEN
             comp.changePassword();
 
             // THEN
-            expect(service.save).toHaveBeenCalledWith('myPassword');
+            expect(service.save).toHaveBeenCalledWith('myPassword1$');
         });
 
         it('should set success to OK upon success', function() {
             // GIVEN
             spyOn(service, 'save').and.returnValue(Observable.of(true));
-            comp.password = comp.confirmPassword = 'myPassword';
+            comp.password = comp.confirmPassword = 'myPassword1$';
 
             // WHEN
             comp.changePassword();
@@ -73,7 +73,7 @@ describe('Component Tests', () => {
         it('should notify of error if change password fails', function() {
             // GIVEN
             spyOn(service, 'save').and.returnValue(Observable.throw('ERROR'));
-            comp.password = comp.confirmPassword = 'myPassword';
+            comp.password = comp.confirmPassword = 'myPassword1$';
 
             // WHEN
             comp.changePassword();


### PR DESCRIPTION
This changes the required 4 (!) characters to have at least 8 characters with a mix of alphanumeric characters with symbols. This matches the password policy of many established services.