### PR TITLE
Fix failure when refresh keys too soon

### DIFF
--- a/radar-auth/src/main/java/org/radarcns/auth/authentication/TokenValidator.java
+++ b/radar-auth/src/main/java/org/radarcns/auth/authentication/TokenValidator.java
@@ -156,10 +156,15 @@ public class TokenValidator {
             } catch (SignatureVerificationException sve) {
                 LOGGER.debug("Client presented a token with an incorrect signature.");
                 if (tryRefresh) {
-                    LOGGER.info("Fetching public keys again...");
-                    refresh();
-                    return validateAccessToken(token, false);
+                    LOGGER.info("Trying to fetch public keys again...");
+                    try {
+                        refresh();
+                    } catch(TokenValidationException ex) {
+                        // Log and Continue with validation
+                        LOGGER.warn("Could not fetch public keys.", ex)
+                    }
                 }
+                return validateAccessToken(token, false);
             } catch (JWTVerificationException ex) {
                 LOGGER.debug("Verifier {} with implementation {} did not accept token {}",
                         verifier.toString(), verifier.getClass().toString(), token);

--- a/radar-auth/src/main/java/org/radarcns/auth/authentication/TokenValidator.java
+++ b/radar-auth/src/main/java/org/radarcns/auth/authentication/TokenValidator.java
@@ -161,7 +161,7 @@ public class TokenValidator {
                         refresh();
                     } catch(TokenValidationException ex) {
                         // Log and Continue with validation
-                        LOGGER.warn("Could not fetch public keys.", ex)
+                        LOGGER.warn("Could not fetch public keys.", ex);
                     }
                     return validateAccessToken(token, false);
                 }

--- a/radar-auth/src/main/java/org/radarcns/auth/authentication/TokenValidator.java
+++ b/radar-auth/src/main/java/org/radarcns/auth/authentication/TokenValidator.java
@@ -159,7 +159,7 @@ public class TokenValidator {
                     LOGGER.info("Trying to fetch public keys again...");
                     try {
                         refresh();
-                    } catch(TokenValidationException ex) {
+                    } catch (TokenValidationException ex) {
                         // Log and Continue with validation
                         LOGGER.warn("Could not fetch public keys.", ex);
                     }

--- a/radar-auth/src/main/java/org/radarcns/auth/authentication/TokenValidator.java
+++ b/radar-auth/src/main/java/org/radarcns/auth/authentication/TokenValidator.java
@@ -163,8 +163,8 @@ public class TokenValidator {
                         // Log and Continue with validation
                         LOGGER.warn("Could not fetch public keys.", ex)
                     }
+                    return validateAccessToken(token, false);
                 }
-                return validateAccessToken(token, false);
             } catch (JWTVerificationException ex) {
                 LOGGER.debug("Verifier {} with implementation {} did not accept token {}",
                         verifier.toString(), verifier.getClass().toString(), token);


### PR DESCRIPTION
When too many requests(having a token that throws `SignatureVerificationException` on the first validator) are made too soon (<`fetchTimeout`), then the token validator fails with
 
```
401 org.radarcns.auth.exception.TokenValidationException: Not fetching public key more than once every PT1M
```

This PR ensures it validates the tokens even when refreshing of public keys fails (in our case due to requesting refresh too soon).