### PR TITLE
Data Class Properties made Public

### DIFF
--- a/managementportal-client/src/main/kotlin/org/radarbase/management/client/MPSourceData.kt
+++ b/managementportal-client/src/main/kotlin/org/radarbase/management/client/MPSourceData.kt
@@ -10,22 +10,22 @@
 package org.radarbase.management.client
 
 data class MPSourceData(
-    private val id: Long,
+    val id: Long,
     //Source data type.
-    private val sourceDataType: String,
-    private val sourceDataName: String? = null,
+    val sourceDataType: String,
+    val sourceDataName: String? = null,
     //Default data frequency
-    private val frequency: String? = null,
+    val frequency: String? = null,
     //Measurement unit.
-    private val unit: String? = null,
+    val unit: String? = null,
     // Define if the samples are RAW data or instead they the result of some computation
-    private val processingState: String? = null,
+    val processingState: String? = null,
     //  the storage
-    private val dataClass: String? = null,
-    private val keySchema: String? = null,
-    private val valueSchema: String? = null,
-    private val topic: String? = null,
-    private val provider: String? = null,
-    private val enabled: Boolean = true,
-    private val sourceType: MPSourceType? = null
+    val dataClass: String? = null,
+    val keySchema: String? = null,
+    val valueSchema: String? = null,
+    val topic: String? = null,
+    val provider: String? = null,
+    val enabled: Boolean = true,
+    val sourceType: MPSourceType? = null
 )

--- a/managementportal-client/src/main/kotlin/org/radarbase/management/client/MPUser.kt
+++ b/managementportal-client/src/main/kotlin/org/radarbase/management/client/MPUser.kt
@@ -14,19 +14,19 @@ import java.time.ZonedDateTime
 
 data class MPUser(
     @JsonProperty("login")
-    private val id: String,
+    val id: String,
 
-    private val firstName: String? = null,
-    private val lastName: String? = null,
-    private val email: String? = null,
-    private val activated: Boolean = false,
+    val firstName: String? = null,
+    val lastName: String? = null,
+    val email: String? = null,
+    val activated: Boolean = false,
 
-    private val langKey: String? = null,
-    private val createdBy: String? = null,
+    val langKey: String? = null,
+    val createdBy: String? = null,
 
-    private val createdDate: ZonedDateTime? = null,
-    private val lastModifiedBy: String? = null,
-    private val lastModifiedDate: ZonedDateTime? = null,
-    private val roles: List<MPRole> = listOf(),
-    private val authorities: List<String> = listOf(),
+    val createdDate: ZonedDateTime? = null,
+    val lastModifiedBy: String? = null,
+    val lastModifiedDate: ZonedDateTime? = null,
+    val roles: List<MPRole> = listOf(),
+    val authorities: List<String> = listOf(),
 )


### PR DESCRIPTION
Private properties make it impossible to update to the latest Radar-Jersey.
E.g. https://github.com/RADAR-base/radar-upload-source-connector/blob/master/radar-upload-backend/src/main/java/org/radarbase/upload/dto/Project.kt#L42 — `MPUser#id` can not be accessed.