### PR TITLE
Source type selection fix

### DIFF
--- a/src/main/webapp/app/entities/project/project-dialog.component.ts
+++ b/src/main/webapp/app/entities/project/project-dialog.component.ts
@@ -118,7 +118,8 @@ export class ProjectDialogComponent implements OnInit {
 
     addSourceType(event: NgbTypeaheadSelectItemEvent) {
         const sourceType = event.item as SourceType;
-        this.project.sourceTypes.push(sourceType);
+        let currentSourceTypes = this.project.sourceTypes || [];
+        this.project.sourceTypes = [ ...currentSourceTypes, sourceType ];
         this.sourceTypeInputText = '';
         event.preventDefault();
     }


### PR DESCRIPTION
When a new Project is created, the `project` instance had uninitialized `sourceTypes` field leading to incorrect behavior. Initializing the field when it is edited resolves #587.