### PR TITLE
Feature/delete group confirmation

### DIFF
--- a/src/main/java/org/radarbase/management/repository/SubjectRepository.java
+++ b/src/main/java/org/radarbase/management/repository/SubjectRepository.java
@@ -25,6 +25,10 @@ public interface SubjectRepository extends JpaRepository<Subject, Long>,
         RevisionRepository<Subject, Long, Integer>,
         JpaSpecificationExecutor<Subject> {
 
+    @Query("SELECT count(*) from Subject subject "
+            + "WHERE subject.group.id = :group_id")
+    long countByGroupId(@Param("group_id") Long groupId);
+
     @Query(value = "select distinct subject from Subject subject left join fetch subject.sources "
             + "left join fetch subject.user user "
             + "join user.roles roles where roles.project.projectName = :projectName and roles"
@@ -58,6 +62,12 @@ public interface SubjectRepository extends JpaRepository<Subject, Long>,
             + "SET subject.group.id = null "
             + "WHERE subject.id in :ids")
     void unsetGroupIdByIds(@Param("ids") List<Long> ids);
+
+    @Modifying
+    @Query("UPDATE Subject subject "
+            + "SET subject.group.id = null "
+            + "WHERE subject.group.id = :group_id")
+    void unlinkAllFromGroup(@Param("group_id") Long groupId);
 
     @Query("select subject.sources from Subject subject WHERE subject.id = :id")
     List<Source> findSourcesBySubjectId(@Param("id") Long id);

--- a/src/main/java/org/radarbase/management/repository/SubjectRepository.java
+++ b/src/main/java/org/radarbase/management/repository/SubjectRepository.java
@@ -63,12 +63,6 @@ public interface SubjectRepository extends JpaRepository<Subject, Long>,
             + "WHERE subject.id in :ids")
     void unsetGroupIdByIds(@Param("ids") List<Long> ids);
 
-    @Modifying
-    @Query("UPDATE Subject subject "
-            + "SET subject.group.id = null "
-            + "WHERE subject.group.id = :group_id")
-    void unlinkAllFromGroup(@Param("group_id") Long groupId);
-
     @Query("select subject.sources from Subject subject WHERE subject.id = :id")
     List<Source> findSourcesBySubjectId(@Param("id") Long id);
 

--- a/src/main/java/org/radarbase/management/service/GroupService.java
+++ b/src/main/java/org/radarbase/management/service/GroupService.java
@@ -75,15 +75,26 @@ public class GroupService {
      * Delete the group by name.
      * @param projectName project name
      * @param groupName group name
+     * @param unlinkSubjects unset group for each linked subject
      * @throws NotFoundException if the project or group is not found.
      */
     @Transactional
-    public void deleteGroup(String projectName, String groupName) {
+    public void deleteGroup(String projectName, String groupName, boolean unlinkSubjects) {
         Group group = groupRepository.findByProjectNameAndName(projectName, groupName)
                 .orElseThrow(() -> new NotFoundException(
                         "Group " + groupName + " not found in project " + projectName,
                         GROUP, ERR_GROUP_NOT_FOUND));
 
+        if (unlinkSubjects) {
+            subjectRepository.unlinkAllFromGroup(group.getId());
+        } else {
+            var subjectCount = subjectRepository.countByGroupId(group.getId());
+            if (subjectCount > 0) {
+                var msg = "Group " + groupName + " has subjects. "
+                        + "Add `unlinkSubjects=true` query param to confirm deletion";
+                throw new ConflictException(msg, GROUP, ERR_VALIDATION);
+            }
+        }
         groupRepository.delete(group);
     }
 

--- a/src/main/java/org/radarbase/management/service/GroupService.java
+++ b/src/main/java/org/radarbase/management/service/GroupService.java
@@ -85,9 +85,7 @@ public class GroupService {
                         "Group " + groupName + " not found in project " + projectName,
                         GROUP, ERR_GROUP_NOT_FOUND));
 
-        if (unlinkSubjects) {
-            subjectRepository.unlinkAllFromGroup(group.getId());
-        } else {
+        if (!unlinkSubjects) {
             var subjectCount = subjectRepository.countByGroupId(group.getId());
             if (subjectCount > 0) {
                 var msg = "Group " + groupName + " has subjects. "

--- a/src/main/java/org/radarbase/management/web/rest/GroupResource.java
+++ b/src/main/java/org/radarbase/management/web/rest/GroupResource.java
@@ -25,6 +25,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.MvcUriComponentsBuilder;
 
@@ -107,10 +108,11 @@ public class GroupResource {
      */
     @DeleteMapping("/{groupName:" + Constants.ENTITY_ID_REGEX + "}")
     public ResponseEntity<?> deleteGroup(
+            @RequestParam(defaultValue = "false") Boolean unlinkSubjects,
             @PathVariable String projectName,
             @PathVariable String groupName) throws NotAuthorizedException {
         checkPermissionOnProject(token, PROJECT_UPDATE, projectName);
-        groupService.deleteGroup(projectName, groupName);
+        groupService.deleteGroup(projectName, groupName, unlinkSubjects);
         return ResponseEntity.noContent().build();
     }
 


### PR DESCRIPTION
Description: Return 409 on DELETE {group} if the group has any subjects linked to it. Unlink subjects on deletion if the query parameter is set to true.

#### Checklist:
- [ ] The [Main workflow](https://github.com/RADAR-base/ManagementPortal/actions/workflows/main.yml) has succeeded
- [ ] The [Gatling tests](https://github.com/RADAR-base/ManagementPortal#other-tests) have passed
- [ ] I have logged into the portal running locally with default admin credentials
- [ ] I have updated the README files if this change requires documentation update
- [ ] I have commented my code, particularly in hard-to-understand areas
