### PR TITLE
Group removal warning

### DIFF
--- a/src/main/webapp/app/shared/group/group-delete-dialog.component.ts
+++ b/src/main/webapp/app/shared/group/group-delete-dialog.component.ts
@@ -27,7 +27,7 @@ export class GroupDeleteDialogComponent {
     }
 
     confirmDelete() {
-        this.groupService.delete(this.group.projectName, this.group.name).subscribe(
+        this.groupService.delete(this.group.projectName, this.group.name, true).subscribe(
                 () => {
                     this.eventManager.broadcast({name: 'groupListModification', content: null});
                     this.activeModal.dismiss(true);

--- a/src/main/webapp/app/shared/group/group.component.html
+++ b/src/main/webapp/app/shared/group/group.component.html
@@ -44,8 +44,7 @@
                     <button
                             class="btn btn-danger btn-sm"
                             type="submit"
-                            [routerLink]="['/', { outlets: { popup: 'project-group/'+ project.projectName + '/' + group.id + '/delete'} }]"
-                            replaceUrl="true"
+                            (click)="deleteGroup(group)"
                     >
                         <span class="fa fa-remove"></span>&nbsp;<span [translate]="'entity.action.delete'"></span>
                     </button>

--- a/src/main/webapp/app/shared/group/group.component.ts
+++ b/src/main/webapp/app/shared/group/group.component.ts
@@ -13,6 +13,7 @@ import { BehaviorSubject, Subscription } from 'rxjs';
 import {Group, GroupService, Project} from '..';
 import { AlertService } from '../util/alert.service';
 import { EventManager } from '../util/event-manager.service';
+import {Router} from "@angular/router";
 
 @Component({
     selector: 'jhi-groups',
@@ -33,6 +34,7 @@ export class GroupComponent implements OnInit, OnDestroy, OnChanges {
             private groupService: GroupService,
             private alertService: AlertService,
             private eventManager: EventManager,
+            private router: Router,
     ) {
         this.groups = [];
     }
@@ -71,4 +73,16 @@ export class GroupComponent implements OnInit, OnDestroy, OnChanges {
         }
     }
 
+    deleteGroup(group: Group) {
+        this.groupService.delete(this.project.projectName, group.name).subscribe(
+            () => {
+                this.eventManager.broadcast({name: 'groupListModification', content: null});
+            },
+            (error) => {
+                if(error.status === 409){
+                    this.router.navigate(['/', { outlets: { popup: 'project-group/'+ this.project.projectName + '/' + group.id + '/delete'} }])
+                }
+            }
+        );
+    }
 }

--- a/src/main/webapp/app/shared/group/group.service.ts
+++ b/src/main/webapp/app/shared/group/group.service.ts
@@ -3,6 +3,7 @@ import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { map } from "rxjs/operators";
 import { Group } from "./group.model";
+import { createRequestOption } from "../model/request.utils";
 
 @Injectable({ providedIn: 'root' })
 export class GroupService {
@@ -32,8 +33,10 @@ export class GroupService {
         return this.http.post<Group>(this.resourceUrl(projectName), copy);
     }
 
-    delete(projectName: string, groupName: string): Observable<any> {
-        return this.http.delete(this.resourceUrl(projectName, groupName));
+    delete(projectName: string, groupName: string, forceDelete?: boolean): Observable<any> {
+        return this.http.delete(this.resourceUrl(projectName, groupName), {
+            params: createRequestOption({ unlinkSubjects: forceDelete }),
+        });
     }
 
     addSubjectsToGroup(

--- a/src/main/webapp/i18n/en/group.json
+++ b/src/main/webapp/i18n/en/group.json
@@ -10,7 +10,7 @@
             "updated": "A Group is updated with identifier {{ param }}",
             "deleted": "A Group is deleted with identifier {{ param }}",
             "delete": {
-                "question": "Are you sure you want to delete Group {{ id }}?"
+                "question": "This group has subjects, are you sure you want to delete Group {{ id }}?"
             },
             "detail": {
                 "title": "Group"

--- a/src/main/webapp/i18n/nl/group.json
+++ b/src/main/webapp/i18n/nl/group.json
@@ -10,7 +10,7 @@
             "updated": "De groep {{ param }} is gewijzigd",
             "deleted": "De groep {{ param }} is verwijderd",
             "delete": {
-                "question": "Weet je zeker dat je groep {{ id }} wilt verwijderen?"
+                "question": "Deze groep heeft onderwerpen. Weet u zeker dat u groep {{ id }} wilt verwijderen?"
             },
             "detail": {
                 "title": "Groep"

--- a/src/test/javascript/e2e/cypress/integration/entities/subject.spec.ts
+++ b/src/test/javascript/e2e/cypress/integration/entities/subject.spec.ts
@@ -149,7 +149,6 @@ describe('Subject e2e test', () => {
     it('should be able to delete a group', () => {
         cy.contains('jhi-project-detail ul.nav-tabs .nav-item', 'Groups').click();
         cy.contains('jhi-groups .group-row', 'Test Group C').contains('button', 'Delete').click();
-        cy.contains('jhi-group-delete-dialog button', 'Delete').click();
         cy.get('jhi-groups .group-row').should('have.length', 2);
     });
 


### PR DESCRIPTION
Description: Removal of a group from project gives warning dialog

It provides a warning if a used group is being removed from a project. 
The backend will first return an HTTP 409 error → this triggers a warning “group has subjects, still want to delete”. 
If confirmed, it removes the group from the subjects who were assigned to this group with additional “unlinkSubjects=true” query param.
