### PR TITLE
Continue pulling public key endpoints even if one fails

### DIFF
--- a/radar-auth/src/main/java/org/radarbase/auth/authentication/TokenValidator.java
+++ b/radar-auth/src/main/java/org/radarbase/auth/authentication/TokenValidator.java
@@ -246,7 +246,8 @@ public class TokenValidator {
                 return algorithmLoader.loadAlgorithmsFromJavaWebKeys(publicKeyInfo);
             } else {
                 // Log and Continue Pulling next Endpoints, if any
-                LOGGER.warn("Invalid token signature. Could not load newer public keys");
+                LOGGER.warn("Invalid token signature. Could not load " 
+                        + "public key from {}", serverUri.toURL());
                 return null;
             }
 

--- a/radar-auth/src/main/java/org/radarbase/auth/authentication/TokenValidator.java
+++ b/radar-auth/src/main/java/org/radarbase/auth/authentication/TokenValidator.java
@@ -246,8 +246,7 @@ public class TokenValidator {
                 return algorithmLoader.loadAlgorithmsFromJavaWebKeys(publicKeyInfo);
             } else {
                 // Log and Continue Pulling next Endpoints, if any
-                LOGGER.warn("Invalid token signature. Could not load " 
-                        + "public key from {}", serverUri.toURL());
+                LOGGER.warn("Could not load newer public keys from {}", serverUri.toURL());
                 return null;
             }
 

--- a/radar-auth/src/main/java/org/radarbase/auth/authentication/TokenValidator.java
+++ b/radar-auth/src/main/java/org/radarbase/auth/authentication/TokenValidator.java
@@ -246,7 +246,7 @@ public class TokenValidator {
                 return algorithmLoader.loadAlgorithmsFromJavaWebKeys(publicKeyInfo);
             } else {
                 // Log and Continue Pulling next Endpoints, if any
-                LOGGER.warn("Invalid token signature. Could not load "+ "newer public keys");
+                LOGGER.warn("Invalid token signature. Could not load newer public keys");
                 return null;
             }
 

--- a/radar-auth/src/main/java/org/radarbase/auth/authentication/TokenValidator.java
+++ b/radar-auth/src/main/java/org/radarbase/auth/authentication/TokenValidator.java
@@ -7,6 +7,7 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -215,6 +216,7 @@ public class TokenValidator {
 
         Stream<Algorithm> endpointKeys = streamEmptyIfNull(config.getPublicKeyEndpoints())
                 .map(this::algorithmFromServerPublicKeyEndpoint)
+                .filter(Objects::nonNull)
                 .flatMap(List::stream);
 
         Stream<Algorithm> stringKeys = streamEmptyIfNull(config.getPublicKeys())
@@ -243,8 +245,9 @@ public class TokenValidator {
                         .getKeys().size(), serverUri.toURL());
                 return algorithmLoader.loadAlgorithmsFromJavaWebKeys(publicKeyInfo);
             } else {
-                throw new TokenValidationException("Invalid token signature. Could not load "
-                        + "newer public keys");
+                // Log and Continue Pulling next Endpoints, if any
+                LOGGER.warn("Invalid token signature. Could not load "+ "newer public keys");
+                return null;
             }
 
         } catch (Exception ex) {


### PR DESCRIPTION
Currently, when a public key fails to be pulled from the public key endpoint, it throws an error and stops the rest of the public keys to be pulled (in the list of public key endpoints). This change will allow a warning to be shown instead of an error being thrown, which will continue the process of pulling the rest of the public keys.
