### PR TITLE
Fix/build issues windows os

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,31 +93,9 @@ springBoot {
     buildInfo()
 }
 
-if (OperatingSystem.current().isWindows()) {
-    task pathingJar(type: Jar) {
-        dependsOn configurations.runtime
-        archiveAppendix.set('pathing')
 
-        doFirst {
-            manifest {
-                attributes 'Class-Path': configurations.runtime.files.collect {
-                    it.toURI().toURL().toString().replaceFirst(/file:\/+/, '/').replaceAll(' ', '%20')
-                }.join(' ')
-            }
-        }
-    }
-
-    bootRun {
-        sourceResources sourceSets.main
-        dependsOn pathingJar
-        doFirst {
-            classpath = files("$buildDir/classes/java/main", "$buildDir/resources/main", pathingJar.archivePath)
-        }
-    }
-} else {
-    bootRun {
-        sourceResources sourceSets.main
-    }
+bootRun {
+    sourceResources sourceSets.main
 }
 
 test {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "lint": "ng lint",
     "lint:fix": "ng lint --fix=true",
     "cleanup": "rimraf build/",
-    "start": "ng serve",
+    "start": "NODE_OPTIONS=--openssl-legacy-provider ng serve",
     "build:prod": "ng build --base-href /managementportal/ --configuration production",
     "build:dev": "ng build --configuration development",
     "test": "ng test --no-watch --no-progress --browsers=ChromeHeadlessCI",


### PR DESCRIPTION
Description: Changes to build.gradle to enable building from source on windows and packages.json to circumvent a bug caused by upgrading to node 18+

Fixes #REPLACE_ME_WITH_THE_ISSUE_IF_EXISTS

#### Checklist:
- [x] The [Main workflow](https://github.com/RADAR-base/ManagementPortal/actions/workflows/main.yml) has succeeded
- [ ] The [Gatling tests](https://github.com/RADAR-base/ManagementPortal#other-tests) have passed
- [ ] I have logged into the portal running locally with default admin credentials
- [ ] I have updated the README files if this change requires documentation update
- [ ] I have commented my code, particularly in hard-to-understand areas
