### PR TITLE
change isPrintlocked$ to an observable instead of a behaviorsubject, …

### DIFF
--- a/src/main/webapp/app/shared/util/print.service.ts
+++ b/src/main/webapp/app/shared/util/print.service.ts
@@ -1,12 +1,18 @@
 import { Injectable } from '@angular/core';
-import { BehaviorSubject } from "rxjs";
+import {BehaviorSubject, Observable} from "rxjs";
+import {delay} from "rxjs/operators";
 
 @Injectable({ providedIn: 'root' })
 export class PrintService {
 
-    isPrintLocked$:  BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
+    private _isPrintLocked$:  BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
+
+    isPrintLocked$:  Observable<boolean> = this._isPrintLocked$.pipe(
+        // this delay is needed to propagate the style changes upward to main.component.ts
+        delay(0),
+    );
 
     setPrintLockTo(setTo: boolean) {
-        this.isPrintLocked$.next(setTo)
+            this._isPrintLocked$.next(setTo);
     }
 }


### PR DESCRIPTION
Force angular to detect changes upon setting the printlock. Discussed in #718 [here](https://github.com/RADAR-base/ManagementPortal/pull/718#discussion_r1328560387)

Description: change isPrintlocked$ to an observable instead of a behaviorsubject, and pipe a zero second delay to any changes forcing angular to detect style changes when the printLock is set/removed.

Fixes #719

#### Checklist:
- [ ] The [Main workflow](https://github.com/RADAR-base/ManagementPortal/actions/workflows/main.yml) has succeeded
- [ ] The [Gatling tests](https://github.com/RADAR-base/ManagementPortal#other-tests) have passed
- [ ] I have logged into the portal running locally with default admin credentials
- [ ] I have updated the README files if this change requires documentation update
- [ ] I have commented my code, particularly in hard-to-understand areas
