### PR TITLE
722 wait no longer needed in cypress tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,7 +75,7 @@ jobs:
           yarn e2e
           ./gradlew --stop
 
-      - name: cypress-screenshots-failed-tests
+      - name: Upload screenshots of failed e2e tests
         if: always()
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -58,6 +58,14 @@ jobs:
           yarn e2e
           ./gradlew --stop
 
+      - name: Upload screenshots of failed e2e tests
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          path: src/test/javascript/e2e/cypress/screenshots
+          if-no-files-found: ignore
+          retention-days: 5
+
       - name: Generate github pages
         run: ./gradlew ghPages
         if: startsWith(github.ref, 'refs/tags/')

--- a/src/test/javascript/e2e/cypress/integration/entities/subject.spec.ts
+++ b/src/test/javascript/e2e/cypress/integration/entities/subject.spec.ts
@@ -137,21 +137,25 @@ describe('Subject e2e test', () => {
         cy.get('jhi-subjects #field-sort-by').click();
         cy.get('jhi-subjects #sort-by-login').click();
         cy.get('jhi-subjects #field-order-by').click();
+        // Alternative to cy.wait(100) which prevents waiting too long
         cy.intercept("GET", "/api/projects/radar/subjects?size=20&sort=login,desc").as("sort")
         cy.get('jhi-subjects #order-by-desc').click();
         cy.wait("@sort");
         cy.get('jhi-subjects .subject-row').first().should('contain.text', 'sub-9');
         cy.get('jhi-subjects #field-order-by').click();
         cy.get('jhi-subjects #order-by-asc').click();
+        cy.wait(100);
         cy.get('jhi-subjects .subject-row').eq(0).should('contain.text', 'test-subject-1');
     });
 
     it('should be able to sort subjects by external id in asc/desc order', () => {
         cy.get('jhi-subjects #field-sort-by').click();
         cy.get('jhi-subjects #sort-by-externalId').click();
+        cy.wait(100);
         cy.get('jhi-subjects .subject-row').first().should('contain.text', 'sub-1');
         cy.get('jhi-subjects #field-order-by').click();
         cy.get('jhi-subjects #order-by-desc').click();
+        cy.wait(100);
         cy.get('jhi-subjects .subject-row').eq(0).should('contain.text', 'test-subject-1');
     });
 

--- a/src/test/javascript/e2e/cypress/integration/entities/subject.spec.ts
+++ b/src/test/javascript/e2e/cypress/integration/entities/subject.spec.ts
@@ -138,22 +138,18 @@ describe('Subject e2e test', () => {
         cy.get('jhi-subjects #sort-by-login').click();
         cy.get('jhi-subjects #field-order-by').click();
         cy.get('jhi-subjects #order-by-desc').click();
-        cy.wait(100);
         cy.get('jhi-subjects .subject-row').first().should('contain.text', 'sub-9');
         cy.get('jhi-subjects #field-order-by').click();
         cy.get('jhi-subjects #order-by-asc').click();
-        cy.wait(100);
         cy.get('jhi-subjects .subject-row').eq(0).should('contain.text', 'test-subject-1');
     });
 
     it('should be able to sort subjects by external id in asc/desc order', () => {
         cy.get('jhi-subjects #field-sort-by').click();
         cy.get('jhi-subjects #sort-by-externalId').click();
-        cy.wait(100);
         cy.get('jhi-subjects .subject-row').first().should('contain.text', 'sub-1');
         cy.get('jhi-subjects #field-order-by').click();
         cy.get('jhi-subjects #order-by-desc').click();
-        cy.wait(100);
         cy.get('jhi-subjects .subject-row').eq(0).should('contain.text', 'test-subject-1');
     });
 

--- a/src/test/javascript/e2e/cypress/integration/entities/subject.spec.ts
+++ b/src/test/javascript/e2e/cypress/integration/entities/subject.spec.ts
@@ -137,7 +137,9 @@ describe('Subject e2e test', () => {
         cy.get('jhi-subjects #field-sort-by').click();
         cy.get('jhi-subjects #sort-by-login').click();
         cy.get('jhi-subjects #field-order-by').click();
+        cy.intercept("GET", "/api/projects/radar/subjects?size=20&sort=login,desc").as("sort")
         cy.get('jhi-subjects #order-by-desc').click();
+        cy.wait("@sort");
         cy.get('jhi-subjects .subject-row').first().should('contain.text', 'sub-9');
         cy.get('jhi-subjects #field-order-by').click();
         cy.get('jhi-subjects #order-by-asc').click();


### PR DESCRIPTION
Description: Remove unneeded wait commands from cypress tests

Fixes #722 

#### Checklist:
- [ ] The [Main workflow](https://github.com/RADAR-base/ManagementPortal/actions/workflows/main.yml) has succeeded
- [ ] The [Gatling tests](https://github.com/RADAR-base/ManagementPortal#other-tests) have passed
- [ ] I have logged into the portal running locally with default admin credentials
- [ ] I have updated the README files if this change requires documentation update
- [ ] I have commented my code, particularly in hard-to-understand areas
