### PR TITLE
724 redirect traffic from to managementportal

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,28 +170,50 @@ The code grant flow for OAuth2 clients can be the following:
      ```
      GET /oauth/authorize?client_id=MyId&response_type=code&redirect_uri=https://my.example.com/oauth_redirect
      ```
-     where you replace `MyId` with your OAuth client id. This needs to be done from a interactive 
-     web view, either a browser or a web window. If the user approves, this will redirect to 
-     `https://my.example.com/oauth_redirect?code=abcdef`. In Android, with [https://appauth.io]
-     (AppAuth library), the URL could be `com.example.my://oauth_redirect` for the `com.example.my`
-      app.
-      You can add an optional parameter for `state`. If you add the state parameter, it will be returned with the `code`.
-3. Request a token for your app by doing a POST, again with HTTP basic authentication with as 
-username your OAuth client id, and leaving the password empty:
+   where you replace `MyId` with your OAuth client id. This needs to be done from a interactive
+   web view, either a browser or a web window. If the user approves, this will redirect to
+   `https://my.example.com/oauth_redirect?code=abcdef`. In Android, with [https://appauth.io]
+   (AppAuth library), the URL could be `com.example.my://oauth_redirect` for the `com.example.my`
+   app.
+   You can add an optional parameter for `state`. If you add the state parameter, it will be returned with the `code`.
+3. Request a token for your app by doing a POST, again with HTTP basic authentication with as
+   username your OAuth client id, and leaving the password empty:
     ```
     POST /oauth/token
     Content-Type: application/x-www-form-urlencoded
 
     grant_type=authorization_code&code=abcdef&redirect_uri=https://my.example.com/oauth_redirect
     ```
-    This will respond with the access token and refresh token:
+   This will respond with the access token and refresh token:
     ```json
     {
        "access_token": "...",
        "refresh_token": "..."
     }
     ```
-    Now the app can use the refresh token flow as shown above.
+   Now the app can use the refresh token flow as shown above.
+
+### Client credentials flow
+The code grant flow for OAuth2 clients can also be the following:
+1. Register an oauth-client with grant_type `client_credentials`
+2. Request a token for your app by doing a POST with HTTP basic authentication with as
+   username your OAuth client id and password your OAuth client secret:
+    ```
+    POST /oauth/token
+    Content-Type: application/x-www-form-urlencoded
+
+    grant_type=client_credentials
+    ```
+   This will respond with the access token:
+    ```json
+    {
+        "access_token": "...",
+        "token_type": "bearer",
+      
+        "...": "..."
+    }
+    ```
+   Now the app can use the access token flow.
 
 ### UI Customization
 

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ auto-refreshes when files change on your hard drive.
     ./gradlew
     yarn start
 
-Then open <http://localhost:9000/> to start the interface and sign in with admin/admin.
+Then open <http://localhost:8081/> to start the interface and sign in with admin/admin.
 
 [Yarn][] is also used to manage CSS and JavaScript dependencies used in this application. You can upgrade dependencies by
 specifying a newer version in [package.json](package.json). You can also run `yarn update` and `yarn install` to manage dependencies.

--- a/angular.json
+++ b/angular.json
@@ -88,7 +88,7 @@
           "defaultConfiguration": "development",
           "options": {
             "proxyConfig": "proxy.conf.json",
-            "port": 9000
+            "port": 8081
           }
         },
         "test": {

--- a/proxy.conf.json
+++ b/proxy.conf.json
@@ -9,6 +9,7 @@
             "/swagger-ui"
         ],
         "target": "http://127.0.0.1:8080",
-        "secure": false
+        "secure": false,
+        "pathRewrite": {"^/managementportal" : ""}
     }
 ]


### PR DESCRIPTION
Description: Change some dev-settings to simplify development by making web-requests sent to the Angular Live Development Server (ALDS) follow the same routes as web-requests sent to (locally hosted) prod builds (i.e. the docker images used in this and other repos)

One "breaking" change is that the ALDS is now hosted at port 8081, as this is the default port we host management portal on when hosted in conjunction with other services.

furthermore, requests pointing to {ALDS}/managementportal are redirected to root, and a description of the client credential authorization workflow was added to the readme

Fixes #724

#### Checklist:
- [ ] The [Main workflow](https://github.com/RADAR-base/ManagementPortal/actions/workflows/main.yml) has succeeded
- [ ] The [Gatling tests](https://github.com/RADAR-base/ManagementPortal#other-tests) have passed
- [ ] I have logged into the portal running locally with default admin credentials
- [ ] I have updated the README files if this change requires documentation update
- [ ] I have commented my code, particularly in hard-to-understand areas
