### PR TITLE
Add login failure logs

### DIFF
--- a/src/main/java/org/radarbase/management/service/MetaTokenService.java
+++ b/src/main/java/org/radarbase/management/service/MetaTokenService.java
@@ -101,7 +101,7 @@ public class MetaTokenService {
             }
             return result;
         } else {
-            throw new RequestGoneException("Token already fetched or expired. ",
+            throw new RequestGoneException("Token " + tokenName + " already fetched or expired. ",
                 META_TOKEN, "error.TokenCannotBeSent");
         }
     }


### PR DESCRIPTION
Add logger statements for login failed. This logs the full audit event, for example
```
Login failure: AuditEvent [timestamp=2023-10-02T08:52:38.257998Z, principal=asdgas, type=AUTHENTICATION_FAILURE, data={details={grant_type=password, client_id=ManagementPortalapp, username=asdgas}, type=org.springframework.security.authentication.BadCredentialsException, message=Bad credentials}]
Login failure: AuditEvent [timestamp=2023-10-02T08:52:51.922491Z, principal=admin, type=AUTHENTICATION_FAILURE, data={details={grant_type=password, client_id=ManagementPortalapp, username=admin}, type=org.springframework.security.authentication.BadCredentialsException, message=Bad credentials}]
```

@K1Hyve is that enough, or maybe even too much information? I could log only the `details`, `message` and `type` instead? It will log both `AUTHENICATION_FAILURE` and `AUTHORIZATION_FAILURE`.