### PR TITLE
fix/append-managementportal-to-baseurl

### DIFF
--- a/gradle/openapi.gradle
+++ b/gradle/openapi.gradle
@@ -2,7 +2,7 @@ apply plugin: 'de.undercouch.download'
 
 task generateOpenApiSpec(type: Download) {
     description = "Fetch the OpenAPI spec from the Swagger endpoint. The application needs to be running at http://localhost:8080/."
-    src 'http://localhost:8080/api-docs'
+    src 'http://localhost:8080/managementportal/api-docs'
     dest file('build/swagger-spec/swagger.json')
 }
 

--- a/gradle/openapi.gradle
+++ b/gradle/openapi.gradle
@@ -5,9 +5,3 @@ task generateOpenApiSpec(type: Download) {
     src 'http://localhost:8080/managementportal/api-docs'
     dest file('build/swagger-spec/swagger.json')
 }
-
-task generateOpenApiSpecProd(type: Download) {
-    description = "Fetch the OpenAPI spec from the Swagger endpoint. The application needs to be running at http://localhost:8080/."
-    src 'http://localhost:8080/managementportal/api-docs'
-    dest file('build/swagger-spec/swagger.json')
-}

--- a/package.json
+++ b/package.json
@@ -68,9 +68,8 @@
     "test": "ng test --no-watch --no-progress --browsers=ChromeHeadlessCI",
     "test:watch": "ng test --watch --browsers=Chrome",
     "e2e": "yarn run wait-for-managementportal && ng e2e",
-    "e2e-prod": "yarn run wait-for-managementportal-prod && ng e2e --configuration production",
-    "wait-for-managementportal": "wait-port -t 240000 http://localhost:8080/managementportal/management/health",
-    "wait-for-managementportal-prod": "wait-port -t 240000 http://localhost:8080/managementportal/management/health"
+    "e2e-prod": "yarn run wait-for-managementportal && ng e2e --configuration production",
+    "wait-for-managementportal": "wait-port -t 240000 http://localhost:8080/managementportal/management/health"
   },
   "packageManager": "yarn@3.1.0"
 }

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "lint:fix": "ng lint --fix=true",
     "cleanup": "rimraf build/",
     "start": "ng serve",
-    "build:prod": "ng build --configuration production",
+    "build:prod": "ng build --base-href /managementportal/ --configuration production",
     "build:dev": "ng build --base-href /managementportal/ --configuration development",
     "test": "ng test --no-watch --no-progress --browsers=ChromeHeadlessCI",
     "test:watch": "ng test --watch --browsers=Chrome",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "test:watch": "ng test --watch --browsers=Chrome",
     "e2e": "yarn run wait-for-managementportal && ng e2e",
     "e2e-prod": "yarn run wait-for-managementportal-prod && ng e2e --configuration production",
-    "wait-for-managementportal": "wait-port -t 240000 http://localhost:8080/management/health",
+    "wait-for-managementportal": "wait-port -t 240000 http://localhost:8080/managementportal/management/health",
     "wait-for-managementportal-prod": "wait-port -t 240000 http://localhost:8080/managementportal/management/health"
   },
   "packageManager": "yarn@3.1.0"

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "cleanup": "rimraf build/",
     "start": "ng serve",
     "build:prod": "ng build --configuration production",
-    "build:dev": "ng build --configuration development",
+    "build:dev": "ng build --base-href /managementportal/ --configuration development",
     "test": "ng test --no-watch --no-progress --browsers=ChromeHeadlessCI",
     "test:watch": "ng test --watch --browsers=Chrome",
     "e2e": "yarn run wait-for-managementportal && ng e2e",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "lint:fix": "ng lint --fix=true",
     "cleanup": "rimraf build/",
     "start": "ng serve",
-    "build:prod": "ng build --base-href /managementportal/ --configuration production",
+    "build:prod": "ng build --configuration production",
     "build:dev": "ng build --configuration development",
     "test": "ng test --no-watch --no-progress --browsers=ChromeHeadlessCI",
     "test:watch": "ng test --watch --browsers=Chrome",

--- a/proxy.conf.json
+++ b/proxy.conf.json
@@ -6,8 +6,7 @@
             "/management",
             "/api-docs",
             "/swagger-ui.html",
-            "/swagger-ui",
-            "/managementportal"
+            "/swagger-ui"
         ],
         "target": "http://127.0.0.1:8080/managementportal",
         "secure": false,

--- a/proxy.conf.json
+++ b/proxy.conf.json
@@ -6,10 +6,10 @@
             "/management",
             "/api-docs",
             "/swagger-ui.html",
-            "/swagger-ui"
+            "/swagger-ui",
+            "/managementportal"
         ],
         "target": "http://127.0.0.1:8080",
-        "secure": false,
-        "pathRewrite": {"^/managementportal" : ""}
+        "secure": false
     }
 ]

--- a/proxy.conf.json
+++ b/proxy.conf.json
@@ -6,10 +6,10 @@
             "/management",
             "/api-docs",
             "/swagger-ui.html",
-            "/swagger-ui",
-            "/managementportal"
+            "/swagger-ui"
         ],
-        "target": "http://127.0.0.1:8080",
-        "secure": false
+        "target": "http://127.0.0.1:8080/managementportal",
+        "secure": false,
+        "pathRewrite": {"^/managementportal" : ""}
     }
 ]

--- a/proxy.conf.json
+++ b/proxy.conf.json
@@ -9,6 +9,8 @@
             "/swagger-ui"
         ],
         "target": "http://127.0.0.1:8080/managementportal",
-        "secure": false
+        "secure": false,
+        "pathRewrite": {"^/managementportal" : ""}
     }
+
 ]

--- a/proxy.conf.json
+++ b/proxy.conf.json
@@ -6,9 +6,10 @@
             "/management",
             "/api-docs",
             "/swagger-ui.html",
-            "/swagger-ui"
+            "/swagger-ui",
+            "/managementportal"
         ],
-        "target": "http://127.0.0.1:8080/managementportal",
+        "target": "http://127.0.0.1:8080/managementportal/",
         "secure": false,
         "pathRewrite": {"^/managementportal" : ""}
     }

--- a/proxy.conf.json
+++ b/proxy.conf.json
@@ -9,7 +9,7 @@
             "/swagger-ui",
             "/managementportal"
         ],
-        "target": "http://127.0.0.1:8080/managementportal/",
+        "target": "http://127.0.0.1:8080/managementportal",
         "secure": false,
         "pathRewrite": {"^/managementportal" : ""}
     }

--- a/proxy.conf.json
+++ b/proxy.conf.json
@@ -1,21 +1,15 @@
 [
     {
         "context": [
+            "/oauth",
             "/api",
             "/management",
             "/api-docs",
             "/swagger-ui.html",
             "/swagger-ui"
         ],
-        "target": "http://127.0.0.1:8080/managementportal",
+        "target": "http://127.0.0.1:8080/managementportal/",
         "secure": false,
         "pathRewrite": {"^/managementportal" : ""}
-    },
-    {
-        "context": [
-            "/oauth"
-        ],
-        "target": "http://127.0.0.1:8080/managementportal",
-        "secure": false
     }
 ]

--- a/proxy.conf.json
+++ b/proxy.conf.json
@@ -8,8 +8,7 @@
             "/swagger-ui.html",
             "/swagger-ui"
         ],
-        "target": "http://127.0.0.1:8080/managementportal/",
-        "secure": false,
-        "pathRewrite": {"^/managementportal" : ""}
+        "target": "http://127.0.0.1:8080/managementportal",
+        "secure": false
     }
 ]

--- a/proxy.conf.json
+++ b/proxy.conf.json
@@ -1,7 +1,6 @@
 [
     {
         "context": [
-            "/oauth",
             "/api",
             "/management",
             "/api-docs",
@@ -11,5 +10,12 @@
         "target": "http://127.0.0.1:8080/managementportal",
         "secure": false,
         "pathRewrite": {"^/managementportal" : ""}
+    },
+    {
+        "context": [
+            "/oauth"
+        ],
+        "target": "http://127.0.0.1:8080/managementportal",
+        "secure": false
     }
 ]

--- a/src/gatling/scala/ManagementPortalSimulation.scala
+++ b/src/gatling/scala/ManagementPortalSimulation.scala
@@ -18,7 +18,7 @@ abstract class ManagementPortalSimulation extends Simulation {
     // Log failed HTTP requests
     //context.getLogger("io.gatling.http").setLevel(Level.valueOf("DEBUG"))
 
-    val baseUrl: String = Option(System.getProperty("baseUrl")) getOrElse """http://127.0.0.1:8080"""
+    val baseUrl: String = Option(System.getProperty("baseUrl")) getOrElse """http://127.0.0.1:8080/managementportal"""
 
     val httpConf: HttpProtocolBuilder = http.baseUrl(baseUrl)
             .inferHtmlResources()

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-jre-slim
+FROM eclipse-temurin:17-jdk
 
 ENV SPRING_OUTPUT_ANSI_ENABLED=ALWAYS \
     JHIPSTER_SLEEP=0

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jdk
+FROM eclipse-temurin:17-jre
 
 ENV SPRING_OUTPUT_ANSI_ENABLED=ALWAYS \
     JHIPSTER_SLEEP=0

--- a/src/main/java/org/radarbase/management/repository/CustomAuditEventRepository.java
+++ b/src/main/java/org/radarbase/management/repository/CustomAuditEventRepository.java
@@ -1,15 +1,9 @@
 package org.radarbase.management.repository;
 
-import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.util.List;
-
-import ch.qos.logback.classic.pattern.ClassicConverter;
 import ch.qos.logback.classic.pattern.TargetLengthBasedClassNameAbbreviator;
-import org.radarbase.management.security.Constants;
 import org.radarbase.management.config.audit.AuditEventConverter;
 import org.radarbase.management.domain.PersistentAuditEvent;
+import org.radarbase.management.security.Constants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,6 +12,11 @@ import org.springframework.boot.actuate.audit.AuditEventRepository;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
 
 /**
  * An implementation of Spring Boot's AuditEventRepository.
@@ -28,7 +27,7 @@ public class CustomAuditEventRepository implements AuditEventRepository {
 
     private static final String AUTHORIZATION_FAILURE = "AUTHORIZATION_FAILURE";
 
-    private static final TargetLengthBasedClassNameAbbreviator typeAbbreviator =
+    private static final TargetLengthBasedClassNameAbbreviator TYPE_ABBREVIATOR =
             new TargetLengthBasedClassNameAbbreviator(15);
 
     @Autowired
@@ -64,7 +63,7 @@ public class CustomAuditEventRepository implements AuditEventRepository {
             Object typeObj = event.getData().get("type");
             String errorType;
             if (typeObj instanceof String) {
-                errorType = typeAbbreviator.abbreviate((String) typeObj);
+                errorType = TYPE_ABBREVIATOR.abbreviate((String) typeObj);
             } else {
                 errorType = null;
             }

--- a/src/main/resources/config/application-dev.yml
+++ b/src/main/resources/config/application-dev.yml
@@ -78,8 +78,9 @@ spring:
 server:
     port: 8080
     servlet:
-        session.cookie.secure: false
-        context-path: /managementportal
+      session.cookie.secure: false
+      context-path: /managementportal
+
 
 
 # ===================================================================

--- a/src/main/resources/config/application-dev.yml
+++ b/src/main/resources/config/application-dev.yml
@@ -80,6 +80,9 @@ server:
     servlet:
       session.cookie.secure: false
       context-path: /managementportal
+      session:
+        cookie:
+          path: /
 
 
 

--- a/src/main/resources/config/application-dev.yml
+++ b/src/main/resources/config/application-dev.yml
@@ -79,6 +79,7 @@ server:
     port: 8080
     servlet:
         session.cookie.secure: false
+        context-path: /managementportal
 
 
 # ===================================================================
@@ -87,8 +88,8 @@ server:
 # ===================================================================
 managementportal:
     common:
-        baseUrl: http://localhost:9000 # Modify according to your server's URL
-        managementPortalBaseUrl: http://localhost:8080/
+        baseUrl: http://localhost:8081 # Modify according to your server's URL
+        managementPortalBaseUrl: http://localhost:8080/managementportal
         privacyPolicyUrl: http://info.thehyve.nl/radar-cns-privacy-policy
         adminPassword: admin
         activationKeyTimeoutInSeconds: 86400 # 1 day

--- a/src/main/resources/config/application-prod.yml
+++ b/src/main/resources/config/application-prod.yml
@@ -77,6 +77,9 @@ server:
     port: 8080
     servlet:
         context-path: /managementportal
+        session:
+            cookie:
+                path: /
 
 
 # ===================================================================

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <base href="/" />
+    <base href="/managementportal" />
     <meta charset="utf-8">
     <title>ManagementPortal</title>
     <meta name="description" content="">

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <base href="/managementportal" />
+    <base href="/" />
     <meta charset="utf-8">
     <title>ManagementPortal</title>
     <meta name="description" content="">

--- a/src/test/bash/run-prod-e2e.sh
+++ b/src/test/bash/run-prod-e2e.sh
@@ -25,7 +25,7 @@ docker-compose -f src/main/docker/app.yml up -d # spin up production mode applic
 set +e
 
 # wait for app to be up
-yarn run wait-for-managementportal-prod
+yarn run wait-for-managementportal
 # run e2e tests against production mode
 if ./gradlew generateOpenApiSpec && yarn run e2e; then
   EXIT_STATUS=0

--- a/src/test/bash/run-prod-e2e.sh
+++ b/src/test/bash/run-prod-e2e.sh
@@ -27,7 +27,7 @@ set +e
 # wait for app to be up
 yarn run wait-for-managementportal-prod
 # run e2e tests against production mode
-if ./gradlew generateOpenApiSpecProd && yarn run e2e-prod; then
+if ./gradlew generateOpenApiSpec && yarn run e2e-prod; then
   EXIT_STATUS=0
 else
   EXIT_STATUS=1

--- a/src/test/bash/run-prod-e2e.sh
+++ b/src/test/bash/run-prod-e2e.sh
@@ -27,7 +27,7 @@ set +e
 # wait for app to be up
 yarn run wait-for-managementportal-prod
 # run e2e tests against production mode
-if ./gradlew generateOpenApiSpec && yarn run e2e-prod; then
+if ./gradlew generateOpenApiSpec && yarn run e2e; then
   EXIT_STATUS=0
 else
   EXIT_STATUS=1

--- a/src/test/resources/config/application.yml
+++ b/src/test/resources/config/application.yml
@@ -107,6 +107,6 @@ managementportal:
         persistentMetaTokenTimeout: P31D
     common:
         baseUrl: http://localhost:8080
-        managementPortalBaseUrl: http://localhost:8080
+        managementPortalBaseUrl: http://localhost:8080/managementportal
         privacyPolicyUrl: http://info.thehyve.nl/radar-cns-privacy-policy
         activationKeyTimeoutInSeconds: 86400


### PR DESCRIPTION
No more rerouting in the Angular live development server (ALDS). server.servlet.context-path and managementportal.common.managementportalbaseurl changed in dev to match prod.

Description: change application-dev.properties to more closely match application-prod.properties and revisit some changes made in #725 

Fixes #732

#### Checklist:
- [x] The [Main workflow](https://github.com/RADAR-base/ManagementPortal/actions/workflows/main.yml) has succeeded
- [x] The [Gatling tests](https://github.com/RADAR-base/ManagementPortal#other-tests) have passed
- [x] I have logged into the portal running locally with default admin credentials
- [x] I have updated the README files if this change requires documentation update
- [x] I have commented my code, particularly in hard-to-understand areas
