### PR TITLE
Remove unused hikari config from application properties

### DIFF
--- a/src/main/resources/config/application-prod.yml
+++ b/src/main/resources/config/application-prod.yml
@@ -25,12 +25,6 @@ spring:
     name: managementportal
     username: radarbase
     password: radarbase
-    hikari:
-      data-source-properties:
-        cachePrepStmts: true
-        prepStmtCacheSize: 250
-        prepStmtCacheSqlLimit: 2048
-        useServerPrepStmts: true
   jpa:
     database-platform: org.hibernate.dialect.PostgreSQLDialect
     database: POSTGRESQL


### PR DESCRIPTION
Description: 
- Remove unused hikari config from application properties

Fixes:
- Error: `java.lang.IllegalStateException: The configuration of the pool is sealed once started. Use HikariConfigMXBean for runtime changes.`