### PR TITLE
Add Ory stack configs

### DIFF
--- a/src/main/docker/etc/config/kratos/kratos.yml
+++ b/src/main/docker/etc/config/kratos/kratos.yml
@@ -2,12 +2,12 @@ dsn: memory
 
 serve:
   public:
-    base_url: http://127.0.0.1:4433/
+    base_url: http://localhost:4433/
   admin:
     base_url: http://kratos:4434/
 
 selfservice:
-  default_browser_return_url: http://127.0.0.1:3000/
+  default_browser_return_url: http://localhost:3000/
   allowed_return_urls:
     - "http://127.0.0.1:3000/"
     - "http://127.0.0.1:8080/"
@@ -19,23 +19,6 @@ selfservice:
   methods:
     password:
       enabled: true
-    #    oidc:
-    #      config:
-    #        providers:
-    #          # social sign-in for google. This needs to be tied to a google account. values below were added by bastiaan
-    #          - id: google_d292689d # this is `<provider-id>` in the Authorization callback URL. DO NOT CHANGE IT ONCE SET! current google callback: http://127.0.0.1:4433/self-service/methods/oidc/callback/google_d292689d
-    #            provider: google
-    #            client_id: 922854293804-r3fhl9tom6uutcq5c8fm4592l1t6s3mh.apps.googleusercontent.com # Replace this with the Client ID
-    #            client_secret: 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 # Replace this with the Client secret
-    #            issuer_url: https://accounts.google.com # Replace this with the providers issuer URL
-    #            mapper_url: "base64://bG9jYWwgY2xhaW1zID0gewogIGVtYWlsX3ZlcmlmaWVkOiBmYWxzZSwKfSArIHN0ZC5leHRWYXIoJ2NsYWltcycpOwoKewogIGlkZW50aXR5OiB7CiAgICB0cmFpdHM6IHsKICAgICAgW2lmICdlbWFpbCcgaW4gY2xhaW1zICYmIGNsYWltcy5lbWFpbF92ZXJpZmllZCB0aGVuICdlbWFpbCcgZWxzZSBudWxsXTogY2xhaW1zLmVtYWlsLAogICAgfSwKICB9LAp9"
-    #            # currently: GitHub example from: https://www.ory.sh/docs/kratos/social-signin/data-mapping
-    #            # Alternatively, use an URL:
-    #            # mapper_url: https://storage.googleapis.com/abc-cde-prd/9cac9717f007808bf17
-    #            scope:
-    #              - email
-    #            # supported scopes can be found in your providers dev docs
-    #      enabled: true
     totp:
       config:
         issuer: Kratos
@@ -45,34 +28,34 @@ selfservice:
 
   flows:
     error:
-      ui_url: http://127.0.0.1:3000/error
+      ui_url: http://localhost:3000/error
 
     settings:
-      ui_url: http://127.0.0.1:3000/settings
-
+      ui_url: http://localhost:3000/settings
+  
     recovery:
       enabled: true
-      ui_url: http://127.0.0.1:3000/recovery
-      use: link
+      ui_url: http://localhost:3000/recovery
+      use: code
 
     verification:
       # our current flow necessitates that users reset their password after they activate an account in managementportal,
       # this works as verification
-      ui_url: http://127.0.0.1:3000/verification
+      ui_url: http://localhost:3000/verification
       enabled: true
-      use: link
+      use: code
       after:
-        default_browser_return_url: http://127.0.0.1:3000
+        default_browser_return_url: http://localhost:3000/consent
 
     logout:
       after:
-        default_browser_return_url: http://127.0.0.1:3000/login
+        default_browser_return_url: http://localhost:3000/login
 
     login:
-      ui_url: http://127.0.0.1:3000/login
+      ui_url: http://localhost:3000/login
 
     registration:
-      ui_url: http://127.0.0.1:3000/registration
+      ui_url: http://localhost:3000/registration
       after:
         password:
           hooks:
@@ -104,3 +87,6 @@ courier:
   smtp:
     connection_uri: smtps://test:test@mailslurper:1025/?skip_ssl_verify=true&disable_starttls=true
     from_address: noreply@radar-base.org
+
+oauth2_provider:
+  url: http://hydra:4445

--- a/src/main/docker/etc/config/kratos/webhook_body.jsonnet
+++ b/src/main/docker/etc/config/kratos/webhook_body.jsonnet
@@ -1,0 +1,5 @@
+function(ctx) {
+    identity: if std.objectHas(ctx, "identity") then ctx.identity else null,
+    payload: if std.objectHas(ctx, "flow") && std.objectHas(ctx.flow, "transient_payload") then ctx.flow.transient_payload else null,
+    cookies: ctx.request_cookies
+}

--- a/src/main/docker/managementportal.yml
+++ b/src/main/docker/managementportal.yml
@@ -12,8 +12,10 @@ services:
             - MANAGEMENTPORTAL_FRONTEND_CLIENT_SECRET=secret
             - MANAGEMENTPORTAL_IDENTITYSERVER_ADMINEMAIL=admin-email-here@radar-base.net
             - MANAGEMENTPORTAL_IDENTITYSERVER_SERVERURL=http://kratos:4433
-            - MANAGEMENTPORTAL_IDENTITYSERVER_LOGINURL=http://localhost:3000
+            - MANAGEMENTPORTAL_IDENTITYSERVER_LOGINURL=http://radar-self-enrolment-ui:3000
             - MANAGEMENTPORTAL_IDENTITYSERVER_SERVERADMINURL=http://kratos:4434
+            - MANAGEMENTPORTAL_AUTHSERVER_SERVERURL=http://hydra:4444
+            - MANAGEMENTPORTAL_AUTHSERVER_SERVERADMINURL=http://hydra:4445
             - JHIPSTER_SLEEP=10 # gives time for the database to boot before the application
             - JAVA_OPTS=-Xmx512m -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005 #enables remote debugging
         ports:

--- a/src/main/docker/non_managementportal/docker-compose.yml
+++ b/src/main/docker/non_managementportal/docker-compose.yml
@@ -22,10 +22,10 @@ services:
       - db
       - default
 
-  kratos-selfservice-ui-node:
+  radar-self-enrolment-ui:
     extends:
       file: ../ory_stack.yml
-      service: kratos-selfservice-ui-node
+      service: radar-self-enrolment-ui
     networks:
       - ory
       - default
@@ -60,3 +60,26 @@ services:
     networks:
       - ory
       - default
+
+  postgresd-hydra:
+    extends:
+      file: ../ory_stack.yml
+      service: postgresd-hydra
+    networks:
+      - ory
+
+  hydra-migrate:
+    extends:
+      file: ../ory_stack.yml
+      service: hydra-migrate
+    networks:
+      - ory
+
+  hydra:
+    extends:
+      file: ../ory_stack.yml
+      service: hydra
+    networks:
+      - ory
+      - default
+

--- a/src/main/docker/ory_stack.yml
+++ b/src/main/docker/ory_stack.yml
@@ -1,20 +1,14 @@
 version: '3.8'
 
 services:
-    kratos-selfservice-ui-node:
+    radar-self-enrolment-ui:
         image:
-            oryd/kratos-selfservice-ui-node
+            mpgxvii/radar-self-enrolment-ui:latest
         environment:
-            - LOG_LEAK_SENSITIVE_VALUES=true
-            - KRATOS_PUBLIC_URL=http://kratos:4433
-            - KRATOS_ADMIN_URL=http://kratos:4434
-            - SECURITY_MODE=standalone
-            - KRATOS_BROWSER_URL=http://127.0.0.1:4433
-            - COOKIE_SECRET=unsafe_cookie_secret
-            - CSRF_COOKIE_NAME=radar
-            - CSRF_COOKIE_SECRET=unsafe_csrf_cookie_secret
+            - ORY_SDK_URL=http://kratos:4433/
+            - HYDRA_ADMIN_URL=http://hydra:4445
         ports:
-            - "3000:3000"
+            - "3000:4455"
         volumes:
             - /tmp/ui-node/logs:/root/.npm/_logs
 
@@ -28,6 +22,16 @@ services:
       restart: unless-stopped
       environment:
         - DSN=postgres://kratos:secret@postgresd-kratos/kratos?sslmode=disable&max_conns=20&max_idle_conns=4
+        - SELFSERVICE_FLOWS_REGISTRATION_AFTER_PASSWORD_HOOKS_0_HOOK=web_hook
+        - SELFSERVICE_FLOWS_REGISTRATION_AFTER_PASSWORD_HOOKS_0_CONFIG_METHOD=POST
+        - SELFSERVICE_FLOWS_REGISTRATION_AFTER_PASSWORD_HOOKS_0_CONFIG_URL=http://managementportal-app:8080/managementportal/api/kratos/subjects
+        - SELFSERVICE_FLOWS_REGISTRATION_AFTER_PASSWORD_HOOKS_0_CONFIG_BODY=file:///etc/config/kratos/webhook_body.jsonnet
+        - SELFSERVICE_FLOWS_REGISTRATION_AFTER_PASSWORD_HOOKS_0_CONFIG_RESPONSE_IGNORE=true
+        - SELFSERVICE_FLOWS_REGISTRATION_AFTER_PASSWORD_HOOKS_1_HOOK=session
+        - SELFSERVICE_FLOWS_VERIFICATION_AFTER_HOOKS_0_HOOK=web_hook
+        - SELFSERVICE_FLOWS_VERIFICATION_AFTER_HOOKS_0_CONFIG_METHOD=POST
+        - SELFSERVICE_FLOWS_VERIFICATION_AFTER_HOOKS_0_CONFIG_URL=http://managementportal-app:8080/managementportal/api/kratos/subjects/activate
+        - SELFSERVICE_FLOWS_VERIFICATION_AFTER_HOOKS_0_CONFIG_BODY=file:///etc/config/kratos/webhook_body.jsonnet
       command: serve -c /etc/config/kratos/kratos.yml --dev --watch-courier
       volumes:
         - type: bind
@@ -58,3 +62,47 @@ services:
         ports:
             - "4436:4436"
             - "4437:4437"
+
+    hydra-migrate:
+        image: oryd/hydra:v2.2.0
+        environment:
+          - DSN=postgres://hydra:secret@postgresd-hydra/hydra?sslmode=disable&max_conns=20&max_idle_conns=4
+        command: migrate sql -e --yes
+        restart: on-failure
+
+    hydra:
+        image: oryd/hydra:v2.2.0
+        depends_on:
+          - hydra-migrate
+        ports:
+          - "4444:4444" # Public port
+          - "4445:4445" # Admin port
+          - "5555:5555" # Port for hydra token user
+        command:
+          serve all --dev
+        restart: on-failure # TODO figure out why we need this (incorporate health check into hydra migrate command?)
+        environment:
+          - DSN=postgres://hydra:secret@postgresd-hydra/hydra?sslmode=disable&max_conns=20&max_idle_conns=4
+          - LOG_LEAK_SENSITIVE_VALUES=true
+          - URLS_SELF_ISSUER=http://localhost:4444
+          - URLS_SELF_PUBLIC=http://localhost:4444
+          - URLS_CONSENT=http://localhost:3000/consent
+          - URLS_LOGIN=http://localhost:3000/login
+          - URLS_LOGOUT=http://localhost:3000/logout
+          - URLS_IDENTITY_PROVIDER_PUBLICURL=http://localhost:4433
+          - URLS_IDENTITY_PROVIDER_URL=http://localhost:4434
+          - SECRETS_SYSTEM=youReallyNeedToChangeThis
+          - OIDC_SUBJECT_IDENTIFIERS_SUPPORTED_TYPES=public,pairwise
+          - OIDC_SUBJECT_IDENTIFIERS_PAIRWISE_SALT=youReallyNeedToChangeThis
+          - STRATEGIES_ACCESS_TOKEN=jwt
+          - SERVE_PUBLIC_CORS_ENABLED=true
+          - SERVE_ADMIN_CORS_ENABLED=true
+          - OAUTH2_ALLOWED_TOP_LEVEL_CLAIMS=scope,roles,authorities,sources,user_name
+          - OAUTH2_MIRROR_TOP_LEVEL_CLAIMS=false
+
+    postgresd-hydra:
+        image: postgres:11.8
+        environment:
+          - POSTGRES_USER=hydra
+          - POSTGRES_PASSWORD=secret
+          - POSTGRES_DB=hydra

--- a/src/main/docker/ory_stack.yml
+++ b/src/main/docker/ory_stack.yml
@@ -10,7 +10,7 @@ services:
             - ORY_SDK_URL=http://kratos:4433/
             - HYDRA_ADMIN_URL=http://hydra:4445
         ports:
-            - "3000:4455"
+            - "3000:3000"
         volumes:
             - /tmp/ui-node/logs:/root/.npm/_logs
 

--- a/src/main/docker/ory_stack.yml
+++ b/src/main/docker/ory_stack.yml
@@ -5,8 +5,7 @@ volumes:
 
 services:
     radar-self-enrolment-ui:
-        image:
-            mpgxvii/radar-self-enrolment-ui:latest
+        image: ghcr.io/radar-base/radar-self-enrolment-ui:dev
         environment:
             - ORY_SDK_URL=http://kratos:4433/
             - HYDRA_ADMIN_URL=http://hydra:4445


### PR DESCRIPTION
Description:

- Updates existing `kratos` config
- Adds new Ory components: `radar-self-enrolment-ui` and `hydra`
- Also has the Kratos -> MP webhook configs
- Docker image for self-enrolment UI is here temporarily: `mpgxvii/radar-self-enrolment-ui:latest`

#### Checklist:
- [ ] The [Main workflow](https://github.com/RADAR-base/ManagementPortal/actions/workflows/main.yml) has succeeded
- [ ] The [Gatling tests](https://github.com/RADAR-base/ManagementPortal#other-tests) have passed
- [ ] I have logged into the portal running locally with default admin credentials
- [ ] I have updated the README files if this change requires documentation update
- [ ] I have commented my code, particularly in hard-to-understand areas
