### PR TITLE
bugfix/http-static-variable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ apply plugin: 'io.spring.dependency-management'
 
 allprojects {
     group 'org.radarbase'
-    version '2.1.2' // project version
+    version '2.1.3' // project version
 
     // The comment on the previous line is only there to identify the project version line easily
     // with a sed command, to auto-update the version number with the prepare-release-branch.sh

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "management-portal",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Description for ManagementPortal",
   "private": true,
   "cacheDirectories": [

--- a/radar-auth/src/main/java/org/radarbase/auth/jwks/JwksTokenVerifierLoader.kt
+++ b/radar-auth/src/main/java/org/radarbase/auth/jwks/JwksTokenVerifierLoader.kt
@@ -52,7 +52,7 @@ class JwksTokenVerifierLoader(
 
     private suspend fun fetchPublicKeyInfo(): JsonWebKeySet = withContext(Dispatchers.IO) {
         logger.info("Getting the JWT public key at {}", url)
-        val response = httpClient.request()
+        val response = httpClient.request(url)
 
         if (!response.status.isSuccess()) {
             throw TokenValidationException("Cannot fetch token keys (${response.status}) - ${response.bodyAsText()}")
@@ -91,7 +91,6 @@ class JwksTokenVerifierLoader(
                 })
             }
             defaultRequest {
-                url(this@JwksTokenVerifierLoader.url)
                 accept(ContentType.Application.Json)
             }
         }

--- a/radar-auth/src/main/java/org/radarbase/auth/jwks/JwksTokenVerifierLoader.kt
+++ b/radar-auth/src/main/java/org/radarbase/auth/jwks/JwksTokenVerifierLoader.kt
@@ -28,23 +28,6 @@ class JwksTokenVerifierLoader(
     private val resourceName: String,
     private val algorithmParser: JwkParser,
 ) : TokenVerifierLoader {
-    private val httpClient = HttpClient(CIO).config {
-        install(HttpTimeout) {
-            connectTimeoutMillis = Duration.ofSeconds(10).toMillis()
-            socketTimeoutMillis = Duration.ofSeconds(10).toMillis()
-            requestTimeoutMillis = Duration.ofSeconds(30).toMillis()
-        }
-        install(ContentNegotiation) {
-            json(Json {
-                ignoreUnknownKeys = true
-                coerceInputValues = true
-            })
-        }
-        defaultRequest {
-            url(this@JwksTokenVerifierLoader.url)
-            accept(ContentType.Application.Json)
-        }
-    }
 
     override suspend fun fetch(): List<TokenVerifier> {
         val keySet = try {
@@ -94,5 +77,23 @@ class JwksTokenVerifierLoader(
         }
 
         private val logger = LoggerFactory.getLogger(JwksTokenVerifierLoader::class.java)
+
+        private val httpClient = HttpClient(CIO).config {
+            install(HttpTimeout) {
+                connectTimeoutMillis = Duration.ofSeconds(10).toMillis()
+                socketTimeoutMillis = Duration.ofSeconds(10).toMillis()
+                requestTimeoutMillis = Duration.ofSeconds(30).toMillis()
+            }
+            install(ContentNegotiation) {
+                json(Json {
+                    ignoreUnknownKeys = true
+                    coerceInputValues = true
+                })
+            }
+            defaultRequest {
+                url(this@JwksTokenVerifierLoader.url)
+                accept(ContentType.Application.Json)
+            }
+        }
     }
 }


### PR DESCRIPTION
# Description:
This PR will apply a hotfix that fixes:
- spurious instantiation of the Ktor HttpClient used for Jwt validation
- redundant token validation by using Jwt token present in the HTTP session

#### Checklist:
- [x] The [Main workflow](https://github.com/RADAR-base/ManagementPortal/actions/workflows/main.yml) has succeeded
- [ ] The [Gatling tests](https://github.com/RADAR-base/ManagementPortal#other-tests) have passed
- [x] I have logged into the portal running locally with default admin credentials:
![image](https://github.com/user-attachments/assets/28c271d8-426c-4d3e-aaa4-02c572875ad3)
- [x] I have updated the README files if this change requires documentation update
- [x] I have commented my code, particularly in hard-to-understand areas
