### PR TITLE
Add support for Sentry monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,28 +3,36 @@
 [![Latest release](https://img.shields.io/github/v/release/RADAR-base/ManagementPortal)](https://github.com/RADAR-base/ManagementPortal/releases/latest)
 [![Build Status](https://github.com/RADAR-base/ManagementPortal/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/RADAR-base/ManagementPortal/actions/workflows/main.yml?query=branch%3Amaster)
 
-Management Portal is an application which is used to manage clinical studies for [RADAR-base](https://www.radar-base.org/) platform.
+Management Portal is an application which is used to manage clinical studies
+for [RADAR-base](https://www.radar-base.org/) platform.
 
 ## Table of contents
-
-- [Quickstart](#quickstart)
+<!-- TOC -->
+* [Dependencies](#dependencies)
+* [Quickstart](#quickstart)
   * [Using Docker-Compose](#using-docker-compose)
   * [Build from source](#build-from-source)
-- [Configuration](#configuration)
+* [Configuration](#configuration)
   * [Environment Variables](#environment-variables)
   * [OAuth Clients](#oauth-clients)
-  * [User management by Ory](#user-management)
+  * [Authorization Code flow](#authorization-code-flow)
+  * [Client credentials flow](#client-credentials-flow)
+  * [User management](#user-management)
   * [UI Customization](#ui-customization)
-- [Development](#development)
+  * [Sentry monitoring](#sentry-monitoring)
+* [Development](#development)
   * [Managing dependencies](#managing-dependencies)
   * [Using angular-cli](#using-angular-cli)
-- [Building for production](#building-for-production)
-- [Testing](#testing)
+* [On Production](#on-production)
+  * [Building for production](#building-for-production)
+  * [Hosting in production](#hosting-in-production)
+* [Testing](#testing)
   * [Client tests](#client-tests)
   * [Other tests](#other-tests)
-- [Using Docker to simplify development (optional)](#using-docker-to-simplify-development-optional)
-- [Documentation](#documentation)
-- [Client libraries](#client-libraries)
+* [Using Docker to simplify development (optional)](#using-docker-to-simplify-development-optional)
+* [Documentation](#documentation)
+* [Client libraries](#client-libraries)
+<!-- TOC -->
 
 ## Dependencies
 
@@ -36,12 +44,14 @@ The following are the prerequisites to run ManagementPortal from source on your 
 
 ## Quickstart
 
-Management Portal can be easily run either by running from source or by using the provided `docker-compose` file.  For documentation on how to run ManagementPortal in production, please see [RADAR-Kubernetes][].
+Management Portal can be easily run either by running from source or by using the provided `docker-compose` file. For
+documentation on how to run ManagementPortal in production, please see [RADAR-Kubernetes][].
 
 ### Using Docker-Compose
 
 The quickest way to get Management Portal up and running in production mode is by using the included
-docker-compose files. 
+docker-compose files.
+
 1. Make sure [Docker][] and [Docker-Compose][] are installed on your system.
 2. Generate a key pair for signing JWT tokens as follows:
    ```shell
@@ -49,12 +59,16 @@ docker-compose files.
    ```
 3. Now, we can start the stack with `docker-compose -f src/main/docker/management-portal.yml up -d`.
 
-This will start a Postgres database, ManagementPortal and the [kratos identity provider stack](https://www.ory.sh/docs/kratos/ory-kratos-intro). The default password for the `admin`
-account is `admin`. An angular live development server to access the managementportal can be started using the `yarn start` command (see [Development](#development)).
+This will start a Postgres database, ManagementPortal and
+the [kratos identity provider stack](https://www.ory.sh/docs/kratos/ory-kratos-intro). The default password for the
+`admin`
+account is `admin`. An angular live development server to access the managementportal can be started using the
+`yarn start` command (see [Development](#development)).
 
 ### Build from source
 
 You must install and configure the following dependencies on your machine to run from source.
+
 1. [Node.js][]: We use Node to run a development web server and build the project.
    Depending on your system, you can install Node either from source or as a pre-packaged bundle.
 2. [Yarn][]: We use Yarn to manage Node dependencies.
@@ -65,22 +79,24 @@ You must install and configure the following dependencies on your machine to run
    ```
    **Make sure the key password and store password are the same!** This is a requirement for Spring Security.
 
-4. **Profile configurations :** ManagementPortal can be run with either `development` or `production` profile. The table below lists the
-main differences between the profiles. Configure the application using the property file at `src/main/resources/config/application-<profile>.yml`.Read more about configurations [here](#configuration)
-    
-5. Run ManagementPortal by running `./gradlew bootRun -Pprod` or `./gradlew bootRun -Pdev`. Development mode will start an in
-memory database and ManagementPortal. An angular live development server to access the managementportal can be started using the `yarn start` command (see [Development](#development)).
-6. You can log in to the application using `admin:admin`. Please don't forgot to change the password of `admin`, if you are using the application on production environment.
-7. The identity server stack can be started in docker by using the docker compose command `docker-compose -f .\src\main\docker\app.yml up -d kratos kratos-selfservice-ui-node kratos-migrate postgresd-kratos mailslurper`
+4. **Profile configurations :** ManagementPortal can be run with either `development` or `production` profile. The table
+   below lists the
+   main differences between the profiles. Configure the application using the property file at
+   `src/main/resources/config/application-<profile>.yml`.Read more about configurations [here](#configuration)
 
+5. Run ManagementPortal by running `./gradlew bootRun -Pprod` or `./gradlew bootRun -Pdev`. Development mode will start
+   an in
+   memory database and ManagementPortal. An angular live development server to access the managementportal can be
+   started using the `yarn start` command (see [Development](#development)).
+6. You can log in to the application using `admin:admin`. Please don't forgot to change the password of `admin`, if you
+   are using the application on production environment.
+7. The identity server stack can be started in docker by using the docker compose command
+   `docker-compose -f .\src\main\docker\app.yml up -d kratos kratos-selfservice-ui-node kratos-migrate postgresd-kratos mailslurper`
 
-|                                  | Development     | Production                        |
-|----------------------------------|-----------------|-----------------------------------|
-| Database type                    | In-memory       | Postgres                          |
-| Demo data loaded                 | Yes             | No                                |
-
-
-
+|                  | Development | Production |
+|------------------|-------------|------------|
+| Database type    | In-memory   | Postgres   |
+| Demo data loaded | Yes         | No         |
 
 The docker image can be pulled by running `docker pull radarbase/management-portal:latest`.
 
@@ -91,13 +107,11 @@ the `application.yml` and `application-prod.yml` (or `application-dev.yml` when 
 development profile) before building the application, or override the defaults using environment
 variables.
 
-
-
 ### Environment Variables
 
 The table below lists the variables that are most likely in need of change when deploying Management
 Portal. You can find the complete configuration
-in the [application.yml](src/main/resources/config/application.yml) and 
+in the [application.yml](src/main/resources/config/application.yml) and
 [application-prod.yml](src/main/resources/config/application-prod.yml) files. See
 [Spring external configuration](https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html)
 for other options on overriding the default configuration.
@@ -112,7 +126,7 @@ for other options on overriding the default configuration.
 | `MANAGEMENTPORTAL_FRONTEND_CLIENT_SECRET`                   | None, you need to override this                     | OAuth client secret for the frontend                                                                                                                                                                                                        |
 | `MANAGEMENTPORTAL_FRONTEND_ACCESS_TOKEN_VALIDITY_SECONDS`   | `14400`                                             | Frontend access token validity period in seconds                                                                                                                                                                                            |
 | `MANAGEMENTPORTAL_FRONTEND_REFRESH_TOKEN_VALIDITY_SECONDS`  | `259200`                                            | Frontend refresh token validity period in seconds                                                                                                                                                                                           |
-| `MANAGEMENTPORTAL_OAUTH_REQUIREAAL2`                        | `false`                                              | Whether to require AAL2 (2-FA or equivalent) level authentication for access to the managementportal.                                                                                                                                       |
+| `MANAGEMENTPORTAL_OAUTH_REQUIREAAL2`                        | `false`                                             | Whether to require AAL2 (2-FA or equivalent) level authentication for access to the managementportal.                                                                                                                                       |
 | `MANAGEMENTPORTAL_OAUTH_CLIENTS_FILE`                       | `/mp-includes/config/oauth_client_details.csv`      | Location of the OAuth clients file                                                                                                                                                                                                          |
 | `MANAGEMENTPORTAL_OAUTH_KEY_STORE_PASSWORD`                 | `radarbase`                                         | Password for the JWT keystore                                                                                                                                                                                                               |
 | `MANAGEMENTPORTAL_OAUTH_SIGNING_KEY_ALIAS`                  | `radarbase-managementportal-ec`                     | Alias in the keystore of the keypair to use for signing                                                                                                                                                                                     |
@@ -130,49 +144,67 @@ for other options on overriding the default configuration.
 | `RADAR_IS_CONFIG_LOCATION`                                  | `radar-is.yml` from class path                      | Location of additional public-key configuration file.                                                                                                                                                                                       |
 | `JHIPSTER_SLEEP`                                            | `10`                                                | Time in seconds that the application should wait at bootup. Used to allow the database to become ready                                                                                                                                      |
 | `JAVA_OPTS`                                                 | `-Xmx512m`                                          | Options to pass on the JVM                                                                                                                                                                                                                  |
+| `SENTRY_DSN`                                                | None                                                | Sentry DSN. You must also [enable Sentry](#sentry-monitoring) for this.                                                                                                                                                                     |
+| `SENTRY_LOG_LEVEL`                                          | `WARN`                                              | Minimum level of log events sent to Sentry (options: TRACE, DEBUG, INFO, WARN, ERROR). You must also [enable Sentry](#sentry-monitoring) for this.                                                                                          |
 
-Lists cannot directly be encoded by environment variables in this version of Spring. So for example the OAuth checking key aliases need to be encoded using the `SPRING_APPLICATION_JSON` variable. For setting two aliases, set it to `{"managementportal":{"oauth":{"checkingKeyAliases":["one","two"]}}}`, for example. If this list is not set, the signing key will also be used as the checking key.
+Lists cannot directly be encoded by environment variables in this version of Spring. So for example the OAuth checking
+key aliases need to be encoded using the `SPRING_APPLICATION_JSON` variable. For setting two aliases, set it to
+`{"managementportal":{"oauth":{"checkingKeyAliases":["one","two"]}}}`, for example. If this list is not set, the signing
+key will also be used as the checking key.
 
 ### OAuth Clients
 
-ManagementPortal uses `OAuth2` workflow to provide authentication and authorization. To add new OAuth clients, you can add at runtime through the UI, or you can add them to the OAuth clients file
+ManagementPortal uses `OAuth2` workflow to provide authentication and authorization. To add new OAuth clients, you can
+add at runtime through the UI, or you can add them to the OAuth clients file
 referenced by the `MANAGEMENTPORTAL_OAUTH_CLIENTS_FILE` configuration option.
-- If your client is supposed to work with the `Pair app` feature, you need to set a key called `dynamic_registration` to `true` like this `{"dynamic_registration": true}` in its `additional_information` map. See the aRMT and pRMT
-clients for an example. 
-- If your client is `dynamic_registration` enabled, the QR code generated by `Pair app` feature will contain a short-living URL. By doing a `GET` request on that URL the `refresh-token` and related meta-data can be fetched. 
-- If you want to prevent an OAuth client from being altered through the UI, you can add a key `{"protected": true}` in the `additional_information` map. 
 
-If the app is paired via the Pair App dialog, the QR code that will be scanned contains a short-lived URL, e.g. `https://radar-base-url.org/api/meta-token/bMUkowOmTOci`
+- If your client is supposed to work with the `Pair app` feature, you need to set a key called `dynamic_registration` to
+  `true` like this `{"dynamic_registration": true}` in its `additional_information` map. See the aRMT and pRMT
+  clients for an example.
+- If your client is `dynamic_registration` enabled, the QR code generated by `Pair app` feature will contain a
+  short-living URL. By doing a `GET` request on that URL the `refresh-token` and related meta-data can be fetched.
+- If you want to prevent an OAuth client from being altered through the UI, you can add a key `{"protected": true}` in
+  the `additional_information` map.
 
-Your app should access the URL, where it will receive an OAuth2 
-refresh token as well as the platform's base URL and a URL to the privacy policy. No authorization 
+If the app is paired via the Pair App dialog, the QR code that will be scanned contains a short-lived URL, e.g.
+`https://radar-base-url.org/api/meta-token/bMUkowOmTOci`
+
+Your app should access the URL, where it will receive an OAuth2
+refresh token as well as the platform's base URL and a URL to the privacy policy. No authorization
 is required to access this URL. **Important:** For security reasons, the information at this URL can
-only be accessed once. Once it has been accessed it can not be retrieved again. 
+only be accessed once. Once it has been accessed it can not be retrieved again.
 
-The app can use that refresh token to get new access and refresh tokens by doing the following HTTP 
-request to the base URL, using HTTP basic authentication with your OAuth client ID as username, and 
+The app can use that refresh token to get new access and refresh tokens by doing the following HTTP
+request to the base URL, using HTTP basic authentication with your OAuth client ID as username, and
 an empty password.
+
 ```
 POST /oauth/token
 Content-Type: application/x-www-form-urlencoded
 
 grant_type=refresh_token&refresh_token=<refresh_token>
 ```
+
 This will respond with at least the access token and refresh token:
+
 ```json
 {
-   "access_token": "...",
-   "refresh_token": "...",
-   "expires_in": 14400
+    "access_token": "...",
+    "refresh_token": "...",
+    "expires_in": 14400
 }
 ```
-Both tokens are valid for a limited time only. When the access token runs out, you will need to 
-perform another request like the one above, but you need to use the new `refresh_token`, since 
+
+Both tokens are valid for a limited time only. When the access token runs out, you will need to
+perform another request like the one above, but you need to use the new `refresh_token`, since
 refresh tokens are valid only once.
 
 ### Authorization Code flow
+
 The code grant flow for OAuth2 clients can be the following:
-1. Register an oauth-client with grant_type `authorization_code` and add a valid `redirect_uri` to that client. (`e.g. https://my.example.com/oauth_redirect` in this example)
+
+1. Register an oauth-client with grant_type `authorization_code` and add a valid `redirect_uri` to that client. (
+   `e.g. https://my.example.com/oauth_redirect` in this example)
 2. Ask user authorization for your app:
      ```
      GET /oauth/authorize?client_id=MyId&response_type=code&redirect_uri=https://my.example.com/oauth_redirect
@@ -201,7 +233,9 @@ The code grant flow for OAuth2 clients can be the following:
    Now the app can use the refresh token flow as shown above.
 
 ### Client credentials flow
+
 The code grant flow for OAuth2 clients can also be the following:
+
 1. Register an oauth-client with grant_type `client_credentials`
 2. Request a token for your app by doing a POST with HTTP basic authentication with as
    username your OAuth client id and password your OAuth client secret:
@@ -223,10 +257,13 @@ The code grant flow for OAuth2 clients can also be the following:
    Now the app can use the access token flow.
 
 ### User management
-Organizational user management and authorization for the managementportal is performed by [Ory Kratos](https://www.ory.sh/docs/kratos/ory-kratos-intro). The flow for adding users to the portal is as follows:
+
+Organizational user management and authorization for the managementportal is performed
+by [Ory Kratos](https://www.ory.sh/docs/kratos/ory-kratos-intro). The flow for adding users to the portal is as follows:
 
 1. Navigate to the [User management view](http://127.0.0.1:8081/#/user-management) and create a user.
-2. The new user then [resets their password](http://127.0.0.1:3000/recovery) at the kratos self-service node using the link they receive via email.
+2. The new user then [resets their password](http://127.0.0.1:3000/recovery) at the kratos self-service node using the
+   link they receive via email.
 3. Adds [add two-factor authentication](http://127.0.0.1:3000/settings?#totp) at the kratos self-service node
 4. And uses these credentials to log in to the managementportal.
 
@@ -253,11 +290,31 @@ sequenceDiagram
 
 ### UI Customization
 
-You can customize ManagementPortal web app by replacing images located in `src/main/webapp/content/images` with your logos:
+You can customize ManagementPortal web app by replacing images located in `src/main/webapp/content/images` with your
+logos:
+
 - `navbar-logo.png` is a 70x45 (WxH in pixels) image shown at the top of every page;
 - `home-page-logo.png` is shown on the home page only; 350x350 px image recommended.
 
 Once you build the project, you will find these images in `build/www/assets/images`.
+
+### Sentry monitoring
+
+To enable Sentry monitoring:
+
+1. Add the `sentry` profile to active spring profiles.
+2. Set a `SENTRY_DSN` environment variable that points to the desired Sentry DSN.
+3. (Optional) Set the `SENTRY_LOG_LEVEL` environment variable to control the minimum log level of events sent to Sentry.
+   The default log level for Sentry is `ERROR`. Possible values are `TRACE`, `DEBUG`, `INFO`, `WARN`, and `ERROR`.
+
+For further configuration of Sentry via environmental variables see [here](https://docs.sentry.io/platforms/java/configuration/#configuration-via-the-runtime-environment). For instance:
+
+```
+SENTRY_LOG_LEVEL: 'ERROR'
+SENTRY_DSN: 'https://000000000000.ingest.de.sentry.io/000000000000'
+SENTRY_ATTACHSTACKTRACE: true
+SENTRY_STACKTRACE_APP_PACKAGES:  org.radarbase
+```
 
 ## Development
 
@@ -267,7 +324,8 @@ Before you can build this project, you must install and configure the following 
    Depending on your system, you can install Node either from source or as a pre-packaged bundle.
 2. [Yarn][]: We use Yarn to manage Node dependencies.
    Depending on your system, you can install Yarn either from source or as a pre-packaged bundle.
-3. Local SMTP server: currently a simple docker-compose is provided with a local SMTP server. Create `smtp.env` from `smtp.env.template` and modify `application.yml` accordingly.  
+3. Local SMTP server: currently a simple docker-compose is provided with a local SMTP server. Create `smtp.env` from
+   `smtp.env.template` and modify `application.yml` accordingly.
 
 After installing Node, you should be able to run the following command to install development tools.
 You will only need to run this command when dependencies change in [package.json](package.json).
@@ -276,20 +334,22 @@ You will only need to run this command when dependencies change in [package.json
 
 We use yarn scripts and [Webpack][] as our build system.
 
-
 Run the following commands in two separate terminals to create a blissful development experience where your browser
 auto-refreshes when files change on your hard drive.
 
     ./gradlew
     yarn start
 
-Then open <http://localhost:8081/> to start the interface and sign in with the email linked to the admin account (defined in the configuration file under `adminEmail`)
+Then open <http://localhost:8081/> to start the interface and sign in with the email linked to the admin account (
+defined in the configuration file under `adminEmail`)
 Note that auto-refresh only works if you visit localhost:8081, NOT if you visit localhost:8081/managementportal
 
 ### Managing dependencies
 
-[Yarn][] is also used to manage CSS and JavaScript dependencies used in this application. You can upgrade dependencies by
-specifying a newer version in [package.json](package.json). You can also run `yarn update` and `yarn install` to manage dependencies.
+[Yarn][] is also used to manage CSS and JavaScript dependencies used in this application. You can upgrade dependencies
+by
+specifying a newer version in [package.json](package.json). You can also run `yarn update` and `yarn install` to manage
+dependencies.
 Add the `help` flag on any command to see how you can use it. For example, `yarn help update`.
 
 The `yarn run` command will list all the scripts available to run for this project.
@@ -309,21 +369,25 @@ will generate few files:
     update src/main/webapp/app/app.module.ts
 
 ## On Production
+
 ### Building for production
 
 To optimize the ManagementPortal application for production, run:
 
     ./gradlew -Pprod clean bootWar
-### Hosting in production
-The latest Meta-QR code implementation requires REST resources on `api/meta-token/*` should definitely be rate-limited by upstream servers.
 
-This will concatenate and minify the client CSS and JavaScript files. It will also modify `index.html` so it references these new files.
+### Hosting in production
+
+The latest Meta-QR code implementation requires REST resources on `api/meta-token/*` should definitely be rate-limited
+by upstream servers.
+
+This will concatenate and minify the client CSS and JavaScript files. It will also modify `index.html` so it references
+these new files.
 To ensure everything worked, run:
 
     java -jar build/libs/*.war
 
 Then navigate to [http://localhost:8080](http://localhost:8080) in your browser.
-
 
 ## Testing
 
@@ -333,15 +397,20 @@ To launch your application's tests, run:
 
 ### Client tests
 
-Unit tests are run by [Karma][] and written with [Jasmine][]. They're located in `src/test/javascript/` and can be run with:
+Unit tests are run by [Karma][] and written with [Jasmine][]. They're located in `src/test/javascript/` and can be run
+with:
 
     yarn test
 
-UI end-to-end tests are powered by [Cypress][], which is built on top of WebDriverJS. They're located in [src/test/javascript/e2e](src/test/javascript/e2e)
-and can be run by starting Spring Boot in one terminal (`./gradlew bootRun`) and running the tests (`yarn run e2e`) in a second one.
+UI end-to-end tests are powered by [Cypress][], which is built on top of WebDriverJS. They're located
+in [src/test/javascript/e2e](src/test/javascript/e2e)
+and can be run by starting Spring Boot in one terminal (`./gradlew bootRun`) and running the tests (`yarn run e2e`) in a
+second one.
+
 ### Other tests
 
-Performance tests are run by [Gatling][] and written in Scala. They're located in `src/test/gatling` and can be run with:
+Performance tests are run by [Gatling][] and written in Scala. They're located in `src/test/gatling` and can be run
+with:
 
     ./gradlew gatlingRunAll
 
@@ -353,7 +422,8 @@ For more information, refer to the [Running tests page][].
 
 ## Using Docker to simplify development (optional)
 
-You can use Docker to improve your JHipster development experience. A number of docker-compose configuration are available in the [src/main/docker](src/main/docker) folder to launch required third party services.
+You can use Docker to improve your JHipster development experience. A number of docker-compose configuration are
+available in the [src/main/docker](src/main/docker) folder to launch required third party services.
 For example, to start a postgreSQL database in a docker container, run:
 
     docker-compose -f src/main/docker/postgresql.yml up -d
@@ -371,11 +441,14 @@ Then run:
 
     docker-compose -f src/main/docker/app.yml up -d
 
-For more information refer to [Using Docker and Docker-Compose][], this page also contains information on the docker-compose sub-generator (`yo jhipster:docker-compose`), which is able to generate docker configurations for one or several JHipster applications.
+For more information refer to [Using Docker and Docker-Compose][], this page also contains information on the
+docker-compose sub-generator (`yo jhipster:docker-compose`), which is able to generate docker configurations for one or
+several JHipster applications.
 
 ## Documentation
 
 Please find the links for some of the documentation per category/component
+
 * [management-portal-javadoc](https://radar-base.github.io/ManagementPortal/management-portal-javadoc/)
 * [radar-auth-javadoc](https://radar-base.github.io/ManagementPortal/radar-auth-javadoc/)
 * [managementportal-client-javadoc](https://radar-base.github.io/ManagementPortal/managementportal-client-javadoc/)
@@ -384,41 +457,67 @@ Please find the links for some of the documentation per category/component
 The pages site is published from the `gh-pages` branch, which has its own history. If you want to
 contribute to the documentation, it is probably more convenient to clone a separate copy of this
 repository for working on the `gh-pages` branch:
+
 ```bash
 git clone --branch gh-pages https://github.com/RADAR-base/ManagementPortal.git ManagementPortal-docs
 ```
+
 ## Client libraries
 
-This project provides a Gradle task to generate an [OpenAPI] specification from which client libraries can be automatically generated:
+This project provides a Gradle task to generate an [OpenAPI] specification from which client libraries can be
+automatically generated:
+
 ```bash
 ./gradlew generateOpenApiSpec
 ```
+
 ManagementPortal needs to be running and be accessible at `http://localhost:8080` for this task to work.
 
-The resulting file can be imported into the [Swagger editor][], or used with [Swagger codegen][] to generate client libraries.
+The resulting file can be imported into the [Swagger editor][], or used with [Swagger codegen][] to generate client
+libraries.
 
 [JHipster Homepage and latest documentation]: https://www.jhipster.tech
 
 [RADAR-Kubernetes]: https://github.com/RADAR-base/RADAR-Kubernetes
+
 [Using Docker and Docker-Compose]: https://www.jhipster.tech/docker-compose/
+
 [Running tests page]: https://www.jhipster.tech/running-tests/
+
 [Setting up Continuous Integration]: https://www.jhipster.tech/setting-up-ci/
 
 [Gatling]: https://gatling.io/
+
 [Node.js]: https://nodejs.org/
+
 [Yarn]: https://yarnpkg.org/
+
 [Webpack]: https://webpack.github.io/
+
 [Angular CLI]: https://cli.angular.io/
+
 [BrowserSync]: http://www.browsersync.io/
+
 [Karma]: https://karma-runner.github.io/
+
 [Jasmine]: https://jasmine.github.io
+
 [Cypress]: https://www.cypress.io
+
 [Protractor]: https://angular.github.io/protractor/
+
 [Leaflet]: http://leafletjs.com/
+
 [DefinitelyTyped]: http://definitelytyped.org/
+
 [Docker]: https://docs.docker.com/
+
 [Docker-Compose]: https://docs.docker.com/compose/
+
 [OpenAPI]: https://www.openapis.org/
+
 [Swagger editor]: https://editor.swagger.io/
+
 [Swagger codegen]: https://swagger.io/swagger-codegen/
+
 [OAuth2 spec]: https://tools.ietf.org/html/rfc6749#section-9

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ plugins {
     id 'org.jetbrains.kotlin.plugin.serialization' version '1.9.22' apply false
     id 'org.jetbrains.dokka' version "1.8.20"
     id "org.jetbrains.kotlin.plugin.allopen" version "1.9.10"
+    id "io.sentry.jvm.gradle" version "4.11.0"
 }
 
 apply plugin: 'org.springframework.boot'

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -57,8 +57,15 @@
         <resetJUL>true</resetJUL>
     </contextListener>
 
+    <appender name="Sentry" class="io.sentry.logback.SentryAppender">
+        <minimumEventLevel>${SENTRY_LOG_LEVEL:-ERROR}</minimumEventLevel>
+    </appender>
+
     <root level="WARN">
         <appender-ref ref="CONSOLE"/>
+        <springProfile name="sentry">
+            <appender-ref ref="Sentry"/>
+        </springProfile>
     </root>
 
 </configuration>


### PR DESCRIPTION
Description: This PR will add option to monitor the application with Sentry. Sentry monitoring will be enabled by the following:

1. Add the `sentry` profile to active spring profiles.
2. Set a `SENTRY_DSN` environment variable that points to the desired Sentry DSN.
3. (Optional) Set the `SENTRY_LOG_LEVEL` environment variable to control the minimum log level of events sent to Sentry.
   The default log level for Sentry is `ERROR`. Possible values are `TRACE`, `DEBUG`, `INFO`, `WARN`, and `ERROR`.

The docs were updated with these instructions.

#### Checklist:
- [ ] The [Main workflow](https://github.com/RADAR-base/ManagementPortal/actions/workflows/main.yml) has succeeded
- [ ] The [Gatling tests](https://github.com/RADAR-base/ManagementPortal#other-tests) have passed
- [ ] I have logged into the portal running locally with default admin credentials
- [x] I have updated the README files if this change requires documentation update
- [x] I have commented my code, particularly in hard-to-understand areas
