### PR TITLE
[bugfix] Escape project name in MP request

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ apply plugin: 'io.spring.dependency-management'
 
 allprojects {
     group 'org.radarbase'
-    version '2.1.5' // project version
+    version '2.1.6' // project version
 
     // The comment on the previous line is only there to identify the project version line easily
     // with a sed command, to auto-update the version number with the prepare-release-branch.sh

--- a/managementportal-client/src/main/kotlin/org/radarbase/management/client/MPClient.kt
+++ b/managementportal-client/src/main/kotlin/org/radarbase/management/client/MPClient.kt
@@ -103,7 +103,7 @@ class MPClient(config: Config) {
         page: Int = 0,
         size: Int = Int.MAX_VALUE,
     ): List<MPSubject> = request<List<MPSubject>> {
-        url("api/projects/$projectId/subjects")
+        url("api/projects/$projectId/subjects".encodeURLPath())
         with(url.parameters) {
             append("page", page.toString())
             append("size", size.toString())


### PR DESCRIPTION
# Problem 
Rest source backend has an error when a project name contains a space. This is caused by the management-portal client not encoding the URL before making the request.

# Solution
This PR will add escape of the URL for the api/projects/$projectId/subjects endpoint.