### PR TITLE
Enable CSRF protection

### DIFF
--- a/src/main/java/org/radarbase/management/config/OAuth2ServerConfiguration.kt
+++ b/src/main/java/org/radarbase/management/config/OAuth2ServerConfiguration.kt
@@ -152,8 +152,6 @@ class OAuth2ServerConfiguration {
                 .logoutUrl("/api/logout")
                 .logoutSuccessHandler(logoutSuccessHandler)
                 .and()
-                .csrf()
-                .disable()
                 .addFilterBefore(
                     jwtAuthenticationFilter(),
                     UsernamePasswordAuthenticationFilter::class.java


### PR DESCRIPTION
Description: CodeQL scanning revealed that csrf protection was turned off for Management Portal. Considering that MP uses session cookies this is not advisable. This PR re-activates CSRF.

Fixes https://github.com/RADAR-base/ManagementPortal/security/code-scanning/2

#### Checklist:
- [x] The [Main workflow](https://github.com/RADAR-base/ManagementPortal/actions/workflows/main.yml) has succeeded
- [ ] The [Gatling tests](https://github.com/RADAR-base/ManagementPortal#other-tests) have passed
- [x] I have logged into the portal running locally with default admin credentials
- [ ] I have updated the README files if this change requires documentation update
- [ ] I have commented my code, particularly in hard-to-understand areas
