### PR TITLE
fix: encode projectId in MP client URL 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ apply plugin: 'io.spring.dependency-management'
 
 allprojects {
     group 'org.radarbase'
-    version '2.1.12' // project version
+    version '2.1.13' // project version
 
     // The comment on the previous line is only there to identify the project version line easily
     // with a sed command, to auto-update the version number with the prepare-release-branch.sh

--- a/managementportal-client/src/main/kotlin/org/radarbase/management/client/MPClient.kt
+++ b/managementportal-client/src/main/kotlin/org/radarbase/management/client/MPClient.kt
@@ -103,7 +103,8 @@ class MPClient(config: Config) {
         page: Int = 0,
         size: Int = Int.MAX_VALUE,
     ): List<MPSubject> = request<List<MPSubject>> {
-        url("api/projects/$projectId/subjects")
+        // Encode the URL because projectId may contain whitespaces.
+        url { path("api", "projects", projectId, "subjects") }
         with(url.parameters) {
             append("page", page.toString())
             append("size", size.toString())

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "management-portal",
-  "version": "2.1.12",
+  "version": "2.1.13",
   "description": "Description for ManagementPortal",
   "private": true,
   "cacheDirectories": [


### PR DESCRIPTION
# Problem
When the projectId contains whitespace, the request for /api/projects/<projectId>/subjects fails.

# Solution 
This PR will URL-encode the path so that whitespaces are no longer present in the URL. 