### PR TITLE
Update frontend error handler interceptor

### DIFF
--- a/src/main/webapp/app/blocks/interceptor/errorhandler.interceptor.ts
+++ b/src/main/webapp/app/blocks/interceptor/errorhandler.interceptor.ts
@@ -22,11 +22,10 @@ export class ErrorHandlerInterceptor implements HttpInterceptor {
           tap(
             () => {},
             (err: HttpErrorResponse) => {
-              if (err.status === 401) {
-                  this.injector.get(AuthService).resetAuthentication(
-                    // no redirect needed when just checking whether authentication is present.
-                    request.url !== 'api/account'
-                  );
+              if (err.status === 401 && request.url === 'api/account') {
+                  // If the account endpoint says 401, the user is no longer authenticated:
+                  // clear authentication and redirect to login/access denied.
+                  this.injector.get(AuthService).resetAuthentication(true);
                   return;
               }
               if (err.status === 409 && request.method === 'DELETE') {


### PR DESCRIPTION
Description:

- Update frontend error handler interceptor to only log the user out if `api/account` returns 401

#### Checklist:
- [ ] The [Main workflow](https://github.com/RADAR-base/ManagementPortal/actions/workflows/main.yml) has succeeded
- [ ] The [Gatling tests](https://github.com/RADAR-base/ManagementPortal#other-tests) have passed
- [ ] I have logged into the portal running locally with default admin credentials
- [ ] I have updated the README files if this change requires documentation update
- [ ] I have commented my code, particularly in hard-to-understand areas
